### PR TITLE
feat(ci): consumer-smoke + GH-Packages E2E validate the packed nupkg

### DIFF
--- a/.github/DEVOPS.md
+++ b/.github/DEVOPS.md
@@ -33,6 +33,7 @@ run at least once on the default branch**. Easiest order:
     - `Build Windows`
     - `UI Tests (Windows)`
     - `Pack NuGet`
+    - `Consumer Smoke (packed nupkg)`
 - ✅ **Require linear history**
 - ✅ **Restrict who can push to matching branches** → allow only **vpapenko**
 - ✅ **Block force pushes**
@@ -105,6 +106,23 @@ dotnet nuget add source https://nuget.pkg.github.com/vpapenko/index.json \
   --password <a-github-pat-with-read:packages>
 dotnet add package ColorPicker.Maui --prerelease
 ```
+
+### 4a. Consumer-smoke validation of the packed nupkg
+
+`ColorPickerTestApp` references the library via `ProjectReference`, so it
+can't catch packaging regressions (missing `.targets`, broken MAUI resource
+glob, dropped public type, TFM mismatch, transitive-dep hole). Two extra
+jobs close that gap:
+
+| Job | Triggered on | Source of the package | Purpose |
+|-----|--------------|-----------------------|---------|
+| `build-and-test.yml → consumer-smoke` | every PR (when `pack: true`) | local feed = the just-packed `nupkgs/` artifact | catch packaging bugs **before merge** |
+| `ci.yml → consumer-e2e-github-packages` | every push to `main` | GitHub Packages (just-published preview) | catch upload/index/auth issues that only show up via the real feed |
+
+Both build the [`samples/ConsumerSmoke/`](../samples/ConsumerSmoke/README.md)
+class library against the version under test, on Android **and** Windows
+TFMs. If either job fails on a PR, the underlying package is broken and
+must not be promoted to a release tag.
 
 ---
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -196,3 +196,43 @@ jobs:
           path: nupkgs/*
           if-no-files-found: error
           retention-days: 30
+
+  consumer-smoke:
+    name: Consumer Smoke (packed nupkg)
+    if: ${{ inputs.pack }}
+    runs-on: windows-latest
+    needs: [ pack ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Install MAUI workloads
+        run: dotnet workload install maui-android maui-windows
+      - uses: actions/download-artifact@v4
+        with:
+          name: nupkgs
+          path: ${{ github.workspace }}\nupkgs
+      - name: Register local feed (packed artifacts)
+        shell: pwsh
+        run: |
+          dotnet nuget add source "${{ github.workspace }}\nupkgs" `
+            --name local-colorpicker `
+            --configfile samples/ConsumerSmoke/NuGet.config
+      - name: Restore consumer against packed version
+        shell: pwsh
+        env:
+          VERSION: ${{ needs.pack.outputs.version }}
+        run: |
+          Write-Host "Restoring ConsumerSmoke against ColorPicker.Maui = $env:VERSION"
+          dotnet restore samples/ConsumerSmoke/ConsumerSmoke.csproj `
+            -p:ColorPickerVersion=$env:VERSION
+      - name: Build consumer (Android)
+        run: dotnet build samples/ConsumerSmoke/ConsumerSmoke.csproj --configuration Release --no-restore -f net8.0-android34.0 -p:ColorPickerVersion=${{ needs.pack.outputs.version }}
+      - name: Build consumer (Windows)
+        run: dotnet build samples/ConsumerSmoke/ConsumerSmoke.csproj --configuration Release --no-restore -f net8.0-windows10.0.19041.0 -p:ColorPickerVersion=${{ needs.pack.outputs.version }}
+      - name: Job summary
+        shell: pwsh
+        run: |
+          "## Consumer smoke passed" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          "Consumed `ColorPicker.Maui` **${{ needs.pack.outputs.version }}** from local feed." | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,55 @@ jobs:
           echo "Version: \`${{ needs.build-and-test.outputs.package-version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "Source: \`https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json\`" >> $GITHUB_STEP_SUMMARY
 
+  consumer-e2e-github-packages:
+    name: Consumer E2E (GitHub Packages)
+    needs: [ build-and-test, publish-preview ]
+    if: github.repository == 'vpapenko/ColorPicker.Maui'
+    runs-on: windows-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Install MAUI workloads
+        run: dotnet workload install maui-android maui-windows
+      - name: Register GitHub Packages as authenticated NuGet source
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          dotnet nuget add source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" `
+            --name github-packages `
+            --username "${{ github.repository_owner }}" `
+            --password $env:GH_TOKEN `
+            --store-password-in-clear-text `
+            --configfile samples/ConsumerSmoke/NuGet.config
+      - name: Wait briefly for GH Packages indexing
+        # Just-pushed nupkgs occasionally need a few seconds before they
+        # show up to the restore endpoint. 30s is generous.
+        shell: pwsh
+        run: Start-Sleep -Seconds 30
+      - name: Restore consumer against just-published version
+        shell: pwsh
+        env:
+          VERSION: ${{ needs.build-and-test.outputs.package-version }}
+        run: |
+          Write-Host "Restoring ConsumerSmoke against ColorPicker.Maui = $env:VERSION from GitHub Packages"
+          dotnet restore samples/ConsumerSmoke/ConsumerSmoke.csproj `
+            -p:ColorPickerVersion=$env:VERSION
+      - name: Build consumer (Android)
+        run: dotnet build samples/ConsumerSmoke/ConsumerSmoke.csproj --configuration Release --no-restore -f net8.0-android34.0 -p:ColorPickerVersion=${{ needs.build-and-test.outputs.package-version }}
+      - name: Build consumer (Windows)
+        run: dotnet build samples/ConsumerSmoke/ConsumerSmoke.csproj --configuration Release --no-restore -f net8.0-windows10.0.19041.0 -p:ColorPickerVersion=${{ needs.build-and-test.outputs.package-version }}
+      - name: Job summary
+        shell: pwsh
+        run: |
+          "## Consumer E2E passed" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          "Consumed `ColorPicker.Maui` **${{ needs.build-and-test.outputs.package-version }}** from GitHub Packages." | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+
   draft-release-notes:
     name: Update release draft
     needs: [ build-and-test ]

--- a/samples/ConsumerSmoke/ConsumerSmoke.csproj
+++ b/samples/ConsumerSmoke/ConsumerSmoke.csproj
@@ -32,6 +32,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<!-- MAUI 8 no longer auto-adds Microsoft.Maui.Controls; required to silence MA002. -->
+		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.100" />
 		<PackageReference Include="ColorPicker.Maui" Version="$(ColorPickerVersion)" />
 	</ItemGroup>
 

--- a/samples/ConsumerSmoke/ConsumerSmoke.csproj
+++ b/samples/ConsumerSmoke/ConsumerSmoke.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<!-- TFMs intentionally mirror the library (Android + Windows). iOS/Mac
+		     omitted because the smoke job runs on Windows runners only.
+		     If we add a macOS smoke job later, append net8.0-ios / net8.0-maccatalyst here. -->
+		<TargetFrameworks>net8.0-android34.0</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+
+		<UseMaui>true</UseMaui>
+		<SingleProject>true</SingleProject>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<!-- Class library, not an app: we only need compile-time validation
+		     that the published nupkg can be consumed. -->
+		<OutputType>Library</OutputType>
+		<IsPackable>false</IsPackable>
+
+		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net8.0-android34.0'">21.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-windows'))">10.0.17763.0</SupportedOSPlatformVersion>
+		<TargetPlatformMinVersion Condition="$(TargetFramework.Contains('-windows'))">10.0.17763.0</TargetPlatformMinVersion>
+
+		<RootNamespace>ConsumerSmoke</RootNamespace>
+		<AssemblyName>ConsumerSmoke</AssemblyName>
+
+		<!-- ColorPickerVersion is supplied by CI:
+		       PR smoke   → packed nupkg version from the pack job
+		       Main E2E   → version just published to GitHub Packages
+		     Local devs can override with -p:ColorPickerVersion=x.y.z. -->
+		<ColorPickerVersion Condition="'$(ColorPickerVersion)' == ''">*</ColorPickerVersion>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="ColorPicker.Maui" Version="$(ColorPickerVersion)" />
+	</ItemGroup>
+
+</Project>

--- a/samples/ConsumerSmoke/NuGet.config
+++ b/samples/ConsumerSmoke/NuGet.config
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!--
+    Package sources are layered by CI:
+      - PR smoke: prepends a local source pointing at the just-packed
+        nupkgs/ folder via `dotnet nuget add source` before restore.
+      - Main E2E: prepends https://nuget.pkg.github.com/vpapenko/index.json
+        with GITHUB_TOKEN auth.
+    Locally, `dotnet restore` falls back to nuget.org.
+  -->
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/samples/ConsumerSmoke/README.md
+++ b/samples/ConsumerSmoke/README.md
@@ -1,0 +1,30 @@
+# ConsumerSmoke
+
+Tiny MAUI class library that consumes **ColorPicker.Maui** as a
+`PackageReference` (not a `ProjectReference`). Its sole purpose is to be
+built by CI against the freshly-packed `.nupkg` so packaging regressions
+(missing `.targets`, broken MAUI resource glob, dropped public type, TFM
+mismatch, transitive-dep hole) fail loudly before consumers ever see them.
+
+## How it's used
+
+| Trigger          | Source of the package          | Workflow job                       |
+|------------------|--------------------------------|------------------------------------|
+| Every PR         | Local feed = packed `nupkgs/`  | `build-and-test.yml → consumer-smoke` |
+| Push to `main`   | GitHub Packages (just-published) | `ci.yml → consumer-e2e-github-packages` |
+
+The version restored is supplied by CI via:
+
+```bash
+dotnet restore samples/ConsumerSmoke/ConsumerSmoke.csproj \
+  -p:ColorPickerVersion=<the-version-just-packed-or-published>
+```
+
+## Run locally
+
+```powershell
+# After running `dotnet pack ColorPicker/ColorPicker.csproj -o nupkgs`:
+dotnet nuget add source (Resolve-Path ./nupkgs) -n local-colorpicker --configfile samples/ConsumerSmoke/NuGet.config
+dotnet restore samples/ConsumerSmoke/ConsumerSmoke.csproj -p:ColorPickerVersion=<version>
+dotnet build samples/ConsumerSmoke/ConsumerSmoke.csproj -f net8.0-windows10.0.19041.0
+```

--- a/samples/ConsumerSmoke/SmokeHostBuilder.cs
+++ b/samples/ConsumerSmoke/SmokeHostBuilder.cs
@@ -1,0 +1,15 @@
+namespace ConsumerSmoke;
+
+using ColorPicker.Classes;
+
+/// <summary>
+/// Compile-only validation of the public MauiAppBuilder extension that
+/// consumers are expected to call from their <c>MauiProgram.cs</c>.
+/// If the package ships without this extension (e.g. namespace renamed or
+/// method made internal), the smoke build fails.
+/// </summary>
+public static class SmokeHostBuilder
+{
+    public static MauiAppBuilder Wire(MauiAppBuilder builder)
+        => builder.UseColorPickersAndSliders();
+}

--- a/samples/ConsumerSmoke/SmokePage.xaml
+++ b/samples/ConsumerSmoke/SmokePage.xaml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:cp="clr-namespace:ColorPicker.Controls;assembly=ColorPicker.Maui"
+             xmlns:cp="clr-namespace:ColorPicker.Controls;assembly=ColorPicker"
              x:Class="ConsumerSmoke.SmokePage">
     <!--
         This page is never instantiated at runtime; its sole purpose is to

--- a/samples/ConsumerSmoke/SmokePage.xaml
+++ b/samples/ConsumerSmoke/SmokePage.xaml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:cp="clr-namespace:ColorPicker.Controls;assembly=ColorPicker.Maui"
+             x:Class="ConsumerSmoke.SmokePage">
+    <!--
+        This page is never instantiated at runtime; its sole purpose is to
+        force XAML compilation of every public ColorPicker control so the
+        smoke build fails fast if the package ships a broken XAML namespace
+        or a renamed type.
+    -->
+    <VerticalStackLayout Spacing="12" Padding="12">
+        <cp:ColorWheel x:Name="Wheel" HeightRequest="200" WidthRequest="200" />
+        <cp:ColorTriangle x:Name="Triangle" HeightRequest="200" WidthRequest="200" />
+        <cp:HSLSliders x:Name="Hsl" HeightRequest="120" />
+        <cp:RGBSliders x:Name="Rgb" HeightRequest="120" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/samples/ConsumerSmoke/SmokePage.xaml.cs
+++ b/samples/ConsumerSmoke/SmokePage.xaml.cs
@@ -1,0 +1,22 @@
+namespace ConsumerSmoke;
+
+using ColorPicker.Controls;
+
+public partial class SmokePage : ContentPage
+{
+    public SmokePage()
+    {
+        InitializeComponent();
+
+        // Compile-time references to every control type we publish, so the
+        // smoke build also fails if a control class disappears from the
+        // packed assembly (e.g. accidentally made internal during refactor).
+        _ = typeof(ColorWheel);
+        _ = typeof(ColorTriangle);
+        _ = typeof(HSLSliders);
+        _ = typeof(RGBSliders);
+        _ = typeof(AlphaSlider);
+        _ = typeof(LuminositySlider);
+        _ = typeof(ColorDisc);
+    }
+}


### PR DESCRIPTION
Adds two CI safety nets so packaging regressions are caught before they reach consumers:

## 1. `Consumer Smoke (packed nupkg)` - runs on every PR
A new `samples/ConsumerSmoke/` MAUI class library consumes `ColorPicker.Maui` via **PackageReference** (not ProjectReference). The job downloads the just-packed nupkg, registers it as a local feed, and builds the consumer on both Android + Windows TFMs.

Catches: missing `.targets`/`.props`, broken MAUI resource globs, dropped public types, TFM mismatches, transitive-dependency holes.

## 2. `Consumer E2E (GitHub Packages)` - runs on every push to main
After `publish-preview`, restores the **just-published** version from GH Packages with `GITHUB_TOKEN` auth and builds the smoke consumer on both TFMs. Catches upload, index, and auth issues that the local-feed smoke can't.

## Why
Until now, `ColorPickerTestApp` referenced the library by source (`ProjectReference`), so a broken nupkg would only be discovered by external consumers - or by the user when manually testing before each release tag.