### PR TITLE
Drop SixLabors.ImageSharp; use SkiaSharp in UI tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,6 @@ updates:
           - "xunit*"
           - "Microsoft.NET.Test.Sdk"
           - "Appium*"
-          - "SixLabors.ImageSharp"
 
   # GitHub Actions versions.
   - package-ecosystem: github-actions

--- a/ColorPicker.UITests/ColorPicker.UITests.csproj
+++ b/ColorPicker.UITests/ColorPicker.UITests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Appium.WebDriver" Version="5.0.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
+    <PackageReference Include="SkiaSharp" Version="2.88.8" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>

--- a/ColorPicker.UITests/Infrastructure/PixelImage.cs
+++ b/ColorPicker.UITests/Infrastructure/PixelImage.cs
@@ -1,0 +1,86 @@
+using SkiaSharp;
+
+namespace ColorPicker.UITests.Infrastructure;
+
+/// <summary>
+/// A single RGBA pixel, deliberately matching ImageSharp's <c>Rgba32</c>
+/// field names (<c>R/G/B/A</c>) so existing test code reads identically
+/// after the migration off ImageSharp.
+/// </summary>
+public readonly record struct Pixel(byte R, byte G, byte B, byte A)
+{
+    public static implicit operator Pixel(SKColor c) => new(c.Red, c.Green, c.Blue, c.Alpha);
+}
+
+/// <summary>
+/// Thin, disposable wrapper around <see cref="SKBitmap"/> that exposes
+/// just the imaging surface the UI tests need:
+///   - <c>Width/Height</c>
+///   - <c>this[x, y]</c> pixel read
+///   - <c>Load(bytes|path)</c>, <c>Save(path)</c>
+///   - <c>Crop(x, y, w, h)</c>
+///
+/// We use SkiaSharp because the picker library already depends on it, so
+/// no new transitive dep is introduced — and ImageSharp 4.0 went
+/// commercial-license-only, which we're avoiding.
+/// </summary>
+public sealed class PixelImage : IDisposable
+{
+    private readonly SKBitmap _bitmap;
+
+    private PixelImage(SKBitmap bitmap) => _bitmap = bitmap;
+
+    public int Width  => _bitmap.Width;
+    public int Height => _bitmap.Height;
+
+    /// <summary>RGBA read of the pixel at (x, y). No bounds checking —
+    /// callers (test code) are expected to clip first.</summary>
+    public Pixel this[int x, int y] => _bitmap.GetPixel(x, y);
+
+    public static PixelImage Load(byte[] bytes)
+    {
+        var bmp = SKBitmap.Decode(bytes)
+            ?? throw new InvalidOperationException("SKBitmap.Decode returned null (corrupt or unsupported PNG bytes)");
+        return new PixelImage(bmp);
+    }
+
+    public static PixelImage Load(string path)
+    {
+        var bmp = SKBitmap.Decode(path)
+            ?? throw new InvalidOperationException($"SKBitmap.Decode returned null for path: {path}");
+        return new PixelImage(bmp);
+    }
+
+    public void Save(string path)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        using var data = _bitmap.Encode(SKEncodedImageFormat.Png, 100)
+            ?? throw new InvalidOperationException("SKBitmap.Encode returned null");
+        using var fs = File.Create(path);
+        data.SaveTo(fs);
+    }
+
+    /// <summary>Return a new <see cref="PixelImage"/> covering the rectangle
+    /// (x, y, w, h). Coordinates are clipped to the source bounds.</summary>
+    public PixelImage Crop(int x, int y, int w, int h)
+    {
+        x = Math.Max(0, x);
+        y = Math.Max(0, y);
+        w = Math.Min(w, _bitmap.Width  - x);
+        h = Math.Min(h, _bitmap.Height - y);
+
+        var dst = new SKBitmap(w, h, _bitmap.ColorType, _bitmap.AlphaType);
+        if (!_bitmap.ExtractSubset(dst, new SKRectI(x, y, x + w, y + h)))
+        {
+            // ExtractSubset can fail when row strides don't match; fall back
+            // to a manual blit via SKCanvas.
+            dst.Dispose();
+            dst = new SKBitmap(w, h, _bitmap.ColorType, _bitmap.AlphaType);
+            using var canvas = new SKCanvas(dst);
+            canvas.DrawBitmap(_bitmap, new SKRect(x, y, x + w, y + h), new SKRect(0, 0, w, h));
+        }
+        return new PixelImage(dst);
+    }
+
+    public void Dispose() => _bitmap.Dispose();
+}

--- a/ColorPicker.UITests/Infrastructure/ReferenceImage.cs
+++ b/ColorPicker.UITests/Infrastructure/ReferenceImage.cs
@@ -1,8 +1,3 @@
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.ImageSharp.Processing;
-using SixLabors.ImageSharp.Formats.Png;
-
 namespace ColorPicker.UITests.Infrastructure;
 
 /// <summary>
@@ -59,7 +54,7 @@ public static class ReferenceImage
     /// <summary>Compare two same-size images; return the fraction of pixels
     /// whose sum-of-channel diff exceeds <paramref name="perPixelTol"/>.</summary>
     public static double FractionMismatched(
-        Image<Rgba32> a, Image<Rgba32> b, int perPixelTol)
+        PixelImage a, PixelImage b, int perPixelTol)
     {
         if (a.Width != b.Width || a.Height != b.Height)
             throw new InvalidOperationException(
@@ -80,23 +75,10 @@ public static class ReferenceImage
     }
 
     /// <summary>Crop a screenshot to the rectangle of interest.</summary>
-    public static Image<Rgba32> Crop(Image<Rgba32> source, PixelRect rect)
-    {
-        // Clip to image bounds defensively (anchor maths can be ±1 px).
-        int x = Math.Max(0, rect.X);
-        int y = Math.Max(0, rect.Y);
-        int w = Math.Min(rect.W, source.Width  - x);
-        int h = Math.Min(rect.H, source.Height - y);
-        var crop = source.Clone(ctx => ctx.Crop(new Rectangle(x, y, w, h)));
-        return crop;
-    }
+    public static PixelImage Crop(PixelImage source, PixelRect rect)
+        => source.Crop(rect.X, rect.Y, rect.W, rect.H);
 
-    public static void Save(Image<Rgba32> img, string path)
-    {
-        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-        img.Save(path, new PngEncoder());
-    }
+    public static void Save(PixelImage img, string path) => img.Save(path);
 
-    public static Image<Rgba32> Load(string path) =>
-        SixLabors.ImageSharp.Image.Load<Rgba32>(path);
+    public static PixelImage Load(string path) => PixelImage.Load(path);
 }

--- a/ColorPicker.UITests/Infrastructure/Screenshot.cs
+++ b/ColorPicker.UITests/Infrastructure/Screenshot.cs
@@ -1,5 +1,3 @@
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Windows;
@@ -15,10 +13,10 @@ namespace ColorPicker.UITests.Infrastructure;
 /// </summary>
 public static class Screenshot
 {
-    public static Image<Rgba32> Capture(WindowsDriver driver)
+    public static PixelImage Capture(WindowsDriver driver)
     {
         var bytes = driver.GetScreenshot().AsByteArray;
-        return SixLabors.ImageSharp.Image.Load<Rgba32>(bytes);
+        return PixelImage.Load(bytes);
     }
 
     /// <summary>Map a logical-units rectangle (as reported by the marker)
@@ -47,7 +45,7 @@ public static class Screenshot
             DpiScale: scale);
     }
 
-    public static Rgba32 SampleBox(Image<Rgba32> img, int cx, int cy, int size = 5)
+    public static Pixel SampleBox(PixelImage img, int cx, int cy, int size = 5)
     {
         int half = size / 2;
         long r = 0, g = 0, b = 0, a = 0, n = 0;
@@ -59,11 +57,11 @@ public static class Screenshot
             var p = img[x, y];
             r += p.R; g += p.G; b += p.B; a += p.A; n++;
         }
-        if (n == 0) return new Rgba32(0, 0, 0, 0);
-        return new Rgba32((byte)(r / n), (byte)(g / n), (byte)(b / n), (byte)(a / n));
+        if (n == 0) return new Pixel(0, 0, 0, 0);
+        return new Pixel((byte)(r / n), (byte)(g / n), (byte)(b / n), (byte)(a / n));
     }
 
-    public static int ColorDistance(Rgba32 a, Rgba32 b) =>
+    public static int ColorDistance(Pixel a, Pixel b) =>
         Math.Abs(a.R - b.R) + Math.Abs(a.G - b.G) + Math.Abs(a.B - b.B);
 }
 

--- a/ColorPicker.UITests/PageObjects/ColorSyncTestPageObject.cs
+++ b/ColorPicker.UITests/PageObjects/ColorSyncTestPageObject.cs
@@ -2,8 +2,7 @@ using OpenQA.Selenium;
 using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Interactions;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
+using ColorPicker.UITests.Infrastructure;
 using PointerInputDevice = OpenQA.Selenium.Appium.Interactions.PointerInputDevice;
 
 namespace ColorPicker.UITests.PageObjects;
@@ -101,10 +100,10 @@ public sealed class ColorSyncTestPageObject
     }
 
     /// <summary>Capture the full window screenshot as an RGBA image.</summary>
-    public Image<Rgba32> CaptureWindow()
+    public PixelImage CaptureWindow()
     {
         var bytes = _driver.GetScreenshot().AsByteArray;
-        return SixLabors.ImageSharp.Image.Load<Rgba32>(bytes);
+        return PixelImage.Load(bytes);
     }
 
     /// <summary>Bounds (in screen pixels) of an element within the captured window image.

--- a/ColorPicker.UITests/PageObjects/LayoutTestPageObject.cs
+++ b/ColorPicker.UITests/PageObjects/LayoutTestPageObject.cs
@@ -1,8 +1,7 @@
 using OpenQA.Selenium;
 using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Windows;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
+using ColorPicker.UITests.Infrastructure;
 
 namespace ColorPicker.UITests.PageObjects;
 
@@ -169,12 +168,12 @@ public sealed class LayoutTestPageObject
 
     /// <summary>
     /// Drives a canvas capture and returns the result as a loaded
-    /// <see cref="Image{Rgba32}"/> ready for pixel sampling / diffing.
+    /// <see cref="PixelImage"/> ready for pixel sampling / diffing.
     /// </summary>
-    public Image<Rgba32> CaptureCanvasImage(TimeSpan? timeout = null)
+    public PixelImage CaptureCanvasImage(TimeSpan? timeout = null)
     {
         var path = CaptureCanvas(timeout);
-        return SixLabors.ImageSharp.Image.Load<Rgba32>(path);
+        return PixelImage.Load(path);
     }
 
     static string SafeText(AppiumElement e) { try { return e.Text ?? ""; } catch { return ""; } }

--- a/ColorPicker.UITests/Tests/BackgroundTests.cs
+++ b/ColorPicker.UITests/Tests/BackgroundTests.cs
@@ -1,7 +1,5 @@
 using ColorPicker.UITests.Infrastructure;
 using ColorPicker.UITests.PageObjects;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
 
 namespace ColorPicker.UITests.Tests;
@@ -46,7 +44,7 @@ public class BackgroundTests
         string scenario, int r, int g, int b)
     {
         var (corner, center) = SampleCornerAndCenter(scenario);
-        AssertNear(corner, new Rgba32((byte)r, (byte)g, (byte)b, 255),
+        AssertNear(corner, new Pixel((byte)r, (byte)g, (byte)b, 255),
                    tol: 16, scenario);
         // Sanity: center sample should differ from corner (a control is
         // drawn on top of the background).
@@ -59,11 +57,11 @@ public class BackgroundTests
     {
         // #FF8000 = pure orange. Sanity-checks the hex parser path.
         var (corner, _) = SampleCornerAndCenter("wheel:400x400:bg=#FF8000");
-        AssertNear(corner, new Rgba32(255, 128, 0, 255), tol: 16,
+        AssertNear(corner, new Pixel(255, 128, 0, 255), tol: 16,
                    "wheel:400x400:bg=#FF8000");
     }
 
-    private (Rgba32 corner, Rgba32 center) SampleCornerAndCenter(string scenario)
+    private (Pixel corner, Pixel center) SampleCornerAndCenter(string scenario)
     {
         var page = _fixture.Page;
         page.Apply(scenario);
@@ -75,7 +73,7 @@ public class BackgroundTests
         return (corner, center);
     }
 
-    private static void AssertNear(Rgba32 actual, Rgba32 expected, int tol, string scenario)
+    private static void AssertNear(Pixel actual, Pixel expected, int tol, string scenario)
     {
         int d = Screenshot.ColorDistance(actual, expected);
         Assert.True(d <= tol,

--- a/ColorPicker.UITests/Tests/ColorSyncDataGenerator.cs
+++ b/ColorPicker.UITests/Tests/ColorSyncDataGenerator.cs
@@ -1,7 +1,5 @@
 using ColorPicker.UITests.Infrastructure;
 using ColorPicker.UITests.PageObjects;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
 using Xunit.Abstractions;
 
 namespace ColorPicker.UITests.Tests;
@@ -109,7 +107,7 @@ public sealed class ColorSyncDataGenerator : IClassFixture<SyncTestAppFixture>
     /// avoid the LightGray cell stroke.
     /// </summary>
     private static (int x, int y, int luma) FindDarkestPixel(
-        Image<Rgba32> img, Bounds b, double innerFrac, double outerFrac)
+        PixelImage img, Bounds b, double innerFrac, double outerFrac)
     {
         int side = Math.Min(b.Width, b.Height);
         int ox = b.X + (b.Width  - side) / 2;

--- a/ColorPicker.UITests/Tests/ColorSyncTests.cs
+++ b/ColorPicker.UITests/Tests/ColorSyncTests.cs
@@ -1,6 +1,4 @@
 using ColorPicker.UITests.Infrastructure;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace ColorPicker.UITests.Tests;
 
@@ -94,7 +92,7 @@ public sealed class ColorSyncTests : IClassFixture<SyncTestAppFixture>
     /// rejects "indicator missing / on wrong cell" mutations that a single dark-pixel
     /// scan was missing (see PaintIndicator in SkiaSharpPickerBase).
     /// </summary>
-    private void AssertPickerAt(Image<Rgba32> img, string cellId, string hex)
+    private void AssertPickerAt(PixelImage img, string cellId, string hex)
     {
         if (!ColorSyncExpectedPickerOffsets.Offsets.TryGetValue((cellId, hex), out var rel))
             throw new InvalidOperationException(
@@ -119,7 +117,7 @@ public sealed class ColorSyncTests : IClassFixture<SyncTestAppFixture>
     private const int BlackLuma   = 60;  // 1px black inner/outer rings
 
     private static (bool found, bool hadWhite, bool hadBlack, int maxLuma, int minLuma)
-        ScanForIndicatorRing(Image<Rgba32> img, int cx, int cy, int radius, int whiteLuma, int blackLuma)
+        ScanForIndicatorRing(PixelImage img, int cx, int cy, int radius, int whiteLuma, int blackLuma)
     {
         bool hadWhite = false, hadBlack = false;
         int maxLuma = 0, minLuma = 255;

--- a/ColorPicker.UITests/Tests/ColorSyncUiDrivenTests.cs
+++ b/ColorPicker.UITests/Tests/ColorSyncUiDrivenTests.cs
@@ -1,6 +1,4 @@
 using ColorPicker.UITests.Infrastructure;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace ColorPicker.UITests.Tests;
 
@@ -111,7 +109,7 @@ public sealed class ColorSyncUiDrivenTests : IClassFixture<SyncTestAppFixture>
 
     // ============================== HELPERS ==============================
 
-    private void AssertPickerAt(Image<Rgba32> img, string cellId, string hex)
+    private void AssertPickerAt(PixelImage img, string cellId, string hex)
     {
         var rel = ColorSyncExpectedPickerOffsets.Offsets[(cellId, hex)];
         var b = _fx.Page.GetWheelAreaBounds(cellId);

--- a/ColorPicker.UITests/Tests/PaddingTests.cs
+++ b/ColorPicker.UITests/Tests/PaddingTests.cs
@@ -1,8 +1,6 @@
 using System.Runtime.InteropServices;
 using ColorPicker.UITests.Infrastructure;
 using ColorPicker.UITests.PageObjects;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
 
 namespace ColorPicker.UITests.Tests;
@@ -27,7 +25,7 @@ public class PaddingTests
     private readonly LayoutTestAppFixture _fixture;
     public PaddingTests(LayoutTestAppFixture fixture) => _fixture = fixture;
 
-    private static readonly Rgba32 White = new(255, 255, 255, 255);
+    private static readonly Pixel White = new(255, 255, 255, 255);
 
     [Theory]
     [InlineData("wheel:300x300:bg=white")]

--- a/ColorPicker.UITests/Tests/PixelDiffTests.cs
+++ b/ColorPicker.UITests/Tests/PixelDiffTests.cs
@@ -1,8 +1,6 @@
 using System.Runtime.InteropServices;
 using ColorPicker.UITests.Infrastructure;
 using ColorPicker.UITests.PageObjects;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
 
 namespace ColorPicker.UITests.Tests;
@@ -76,7 +74,7 @@ public class PixelDiffTests
     }
 
     private static void AssertWithin(
-        Image<Rgba32> golden, Image<Rgba32> actual,
+        PixelImage golden, PixelImage actual,
         int perPixelTol, double maxBadFrac, string id, string refPath)
     {
         double bad = ReferenceImage.FractionMismatched(golden, actual, perPixelTol);

--- a/ColorPicker.UITests/Tests/SettingsToggleTests.cs
+++ b/ColorPicker.UITests/Tests/SettingsToggleTests.cs
@@ -80,13 +80,11 @@ public sealed class SettingsToggleTests : IClassFixture<AppFixture>
         }
     }
 
-    private static SixLabors.ImageSharp.Image<SixLabors.ImageSharp.PixelFormats.Rgba32>
-        LoadPng(byte[] bytes) =>
-        SixLabors.ImageSharp.Image.Load<SixLabors.ImageSharp.PixelFormats.Rgba32>(bytes);
+    private static PixelImage LoadPng(byte[] bytes) => PixelImage.Load(bytes);
 
     private static int CountDifferentPixels(
-        SixLabors.ImageSharp.Image<SixLabors.ImageSharp.PixelFormats.Rgba32> a,
-        SixLabors.ImageSharp.Image<SixLabors.ImageSharp.PixelFormats.Rgba32> b,
+        PixelImage a,
+        PixelImage b,
         int x, int y, int w, int h, int channelTol)
     {
         int diff = 0;

--- a/ColorPicker.UITests/Tests/VisualProbe.cs
+++ b/ColorPicker.UITests/Tests/VisualProbe.cs
@@ -1,7 +1,5 @@
 using ColorPicker.UITests.Infrastructure;
 using ColorPicker.UITests.PageObjects;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
 using Xunit;
 using Xunit.Abstractions;
 


### PR DESCRIPTION
**Problem.** `SixLabors.ImageSharp 4.x` switched to a commercial-only license, so PR #10 (Appium.WebDriver + 4 other test-stack bumps from Dependabot) fails its build with `error : No Six Labors license found`.`ImageSharp` was introduced only in the MAUI port (the original Xamarin lib never used it, and the picker library itself doesn't depend on it) — purely as a screenshot read/sample helper for the UI tests.**Fix.** Replace `ImageSharp` with `SkiaSharp`, which the picker library already ships, so no new transitive dependency.A thin `ColorPicker.UITests/Infrastructure/PixelImage.cs` wraps `SKBitmap` and exposes exactly the surface the tests use:- `Width`, `Height`- indexer `this[int x, int y] -> Pixel`- `Load(byte[])` / `Load(string path)`- `Save(string path)` (PNG)- `Crop(x, y, w, h)`The `Pixel` record deliberately keeps `R/G/B/A` (not `Red/Green/Blue/Alpha`) so every existing pixel-sampling test reads identically.Also drops `SixLabors.ImageSharp` from the dependabot `test-stack` group.**Validation.** `dotnet build ColorPicker.UITests -c Release` is clean (0 errors). Full CI / UI Tests / Consumer Smoke will exercise the rest.