### PR TITLE
Tier 3 naming cleanup: fix BindableProperty owner-type bugs + drop stale Wheel/Circle names

### DIFF
--- a/ColorPicker/Controls/ColorDisc.cs
+++ b/ColorPicker/Controls/ColorDisc.cs
@@ -13,7 +13,7 @@ public class ColorDisc : SkiaSharpPickerBase
     public static readonly BindableProperty ShowLuminosityRingProperty 
                          = BindableProperty.Create( nameof(ShowLuminosityRing),
                                                     typeof(bool),
-                                                    typeof(SkiaSharpPickerBase),
+                                                    typeof(ColorDisc),
                                                     true,
                                                     propertyChanged: HandleShowLuminosity );
     public bool ShowLuminosityRing
@@ -30,15 +30,15 @@ public class ColorDisc : SkiaSharpPickerBase
     public static readonly BindableProperty CanvasBackgroundColorProperty 
                          = BindableProperty.Create( nameof(CanvasBackgroundColor),
                                                     typeof(Color),
-                                                    typeof(IColorPicker),
+                                                    typeof(ColorDisc),
                                                     Colors.Transparent,
-                                                    propertyChanged: HandleWheelBackgroundColor );
+                                                    propertyChanged: HandleCanvasBackgroundColor );
     public Color CanvasBackgroundColor
     {
         get => (Color)GetValue( CanvasBackgroundColorProperty );
         set => SetValue( CanvasBackgroundColorProperty, value );
     }
-    static void HandleWheelBackgroundColor( BindableObject bindable, object oldValue, object newValue )
+    static void HandleCanvasBackgroundColor( BindableObject bindable, object oldValue, object newValue )
     {
         if ( newValue != oldValue )
         {
@@ -47,7 +47,7 @@ public class ColorDisc : SkiaSharpPickerBase
     }
 
     /// <summary>
-    /// Constuctor
+    /// Constructor
     /// </summary>
     public ColorDisc()
     {

--- a/ColorPicker/Controls/ColorTriangle.cs
+++ b/ColorPicker/Controls/ColorTriangle.cs
@@ -16,16 +16,16 @@ public class ColorTriangle : SkiaSharpPickerBase
     public static readonly BindableProperty CanvasBackgroundColorProperty
                          = BindableProperty.Create(nameof(CanvasBackgroundColor),
                                                     typeof(Color),
-                                                    typeof(IColorPicker),
+                                                    typeof(ColorTriangle),
                                                     Colors.Transparent,
-                                                    propertyChanged: HandleWheelBackgroundColorSet );
+                                                    propertyChanged: HandleCanvasBackgroundColorChanged );
     public Color CanvasBackgroundColor
     {
         get => (Color)GetValue( CanvasBackgroundColorProperty );
         set => SetValue( CanvasBackgroundColorProperty, value );
     }
 
-    static void HandleWheelBackgroundColorSet( BindableObject bindable, object oldValue, object newValue )
+    static void HandleCanvasBackgroundColorChanged( BindableObject bindable, object oldValue, object newValue )
     {
         if (newValue != oldValue)
         {

--- a/ColorPicker/Controls/ColorWheel.cs
+++ b/ColorPicker/Controls/ColorWheel.cs
@@ -2,7 +2,7 @@ namespace ColorPicker.Controls;
 
 public class ColorWheel : ColorPickerViewBase
 {
-    readonly ColorDisc        _colorCircle        = new();
+    readonly ColorDisc        _disc        = new();
     readonly AlphaSlider        _alphaSlider        = new();
     readonly LuminositySlider   _luminositySlider   = new();
 
@@ -35,7 +35,7 @@ public class ColorWheel : ColorPickerViewBase
                                                     typeof(Color),
                                                     typeof(ColorWheel),
                                                     Colors.Transparent,
-                                                    propertyChanged: HandleWheelBackgroundColor );
+                                                    propertyChanged: HandleCanvasBackgroundColor );
 
     public static readonly BindableProperty IndicatorRadiusScaleProperty 
                          = BindableProperty.Create( nameof(IndicatorRadiusScale),
@@ -57,7 +57,7 @@ public class ColorWheel : ColorPickerViewBase
         set => SetValue( ShowLuminosityRingProperty, value );
     }
     static void HandleShowLuminosity( BindableObject bindable, object oldValue, object newValue )
-            => ( (ColorWheel)bindable )._colorCircle.ShowLuminosityRing = (bool)newValue;
+            => ( (ColorWheel)bindable )._disc.ShowLuminosityRing = (bool)newValue;
 
 
     public bool ShowLuminositySlider
@@ -83,10 +83,10 @@ public class ColorWheel : ColorPickerViewBase
         get => (Color)GetValue( CanvasBackgroundColorProperty );
         set => SetValue( CanvasBackgroundColorProperty, value );
     }
-    static void HandleWheelBackgroundColor( BindableObject bindable, object oldValue, object newValue )
+    static void HandleCanvasBackgroundColor( BindableObject bindable, object oldValue, object newValue )
     {
         if ( newValue != oldValue )
-            ( (ColorWheel)bindable )._colorCircle.CanvasBackgroundColor = (Color)newValue;
+            ( (ColorWheel)bindable )._disc.CanvasBackgroundColor = (Color)newValue;
     }
 
     public float IndicatorRadiusScale
@@ -105,7 +105,7 @@ public class ColorWheel : ColorPickerViewBase
             // size visually consistent with the wheel's own picker. Forwarding
             // a non-zero scale here would force the slider into aspect-locked
             // mode and break the wheel's manual layout.
-            ( (ColorWheel)bindable )._colorCircle.IndicatorRadiusScale = (float)newValue;
+            ( (ColorWheel)bindable )._disc.IndicatorRadiusScale = (float)newValue;
         }
     }
 
@@ -131,12 +131,12 @@ public class ColorWheel : ColorPickerViewBase
     /// </summary>
     public ColorWheel()
     {
-        _colorCircle.AttachedColorPicker    = this;
+        _disc.AttachedColorPicker    = this;
 
         HorizontalOptions                   = LayoutOptions.Center;
         VerticalOptions                     = LayoutOptions.Center;
 
-        Children.Add( _colorCircle );
+        Children.Add( _disc );
 
         _alphaSlider.AttachedColorPicker       = this;
         _luminositySlider.AttachedColorPicker  = this;
@@ -221,8 +221,8 @@ public class ColorWheel : ColorPickerViewBase
 
         // Bounds == natural size (parent honors our DesiredSize via HO/VO=Center),
         // so children are placed at (0,0) with no centering offset needed.
-        ( (IView)_colorCircle ).Measure( circleSize, circleSize );
-        ( (IView)_colorCircle ).Arrange( new Rect( 0, 0, circleSize, circleSize ) );
+        ( (IView)_disc ).Measure( circleSize, circleSize );
+        ( (IView)_disc ).Arrange( new Rect( 0, 0, circleSize, circleSize ) );
 
         if ( Vertical )
         {


### PR DESCRIPTION
Part of the rename pass. **Tier 3 = internal-only, zero public-API change.**

### Latent bugs fixed
Three `BindableProperty.Create` calls had the wrong **declaring-type** argument, which would have caused XAML `<Style TargetType=...>` setters to silently miss those properties (Maui keys bindable properties on the *declaring* type, not the instance type):

| Property | Was | Now |
|---|---|---|
| `ColorDisc.ShowLuminosityRingProperty` | `typeof(SkiaSharpPickerBase)` | `typeof(ColorDisc)` |
| `ColorDisc.CanvasBackgroundColorProperty` | `typeof(IColorPicker)` | `typeof(ColorDisc)` |
| `ColorTriangle.CanvasBackgroundColorProperty` | `typeof(IColorPicker)` | `typeof(ColorTriangle)` |

### Stale names from the Xamarin port
- `ColorWheel._colorCircle` → `_disc` (field still said *Circle* after the class was renamed to `ColorDisc`)
- `HandleWheelBackgroundColor` on `ColorDisc` / `HandleWheelBackgroundColorSet` on `ColorTriangle` → `HandleCanvasBackgroundColor[Changed]` (neither control is a wheel)
- Fixed `Constuctor` typo in `ColorDisc` XML doc

### Out of scope (Tier 1/2 — public API)
A larger rename proposal is queued — `Slider` → `DelegateSlider`, `HSLSliders` → `HslSliderGroup`, `SliderPicker` → `SliderStack`, etc. Will land in a separate PR after explicit go-ahead since those are breaking.

### Validation
- Windows TFM builds clean locally; Android needs CI (no SDK installed locally).
- All 213 UI tests + Consumer Smoke will exercise the changes.