### PR TITLE
refactor: drop misleading 'Wheel' prefix and normalize HSV casing

### DIFF
--- a/ColorPicker/Controls/ColorDisc.cs
+++ b/ColorPicker/Controls/ColorDisc.cs
@@ -165,7 +165,7 @@ public class ColorDisc : SkiaPickerBase
         if ( color.GetLuminosity() != 0 || !IsInHSArea( _locationHS, canvasRadius ) )
         {
             var angleHS  = (0.5 - color.GetHue()) * (2 * Math.PI);
-            var radiusHS = WheelHSRadius(canvasRadius) * color.GetSaturation();
+            var radiusHS = HsRadius(canvasRadius) * color.GetSaturation();
 
             var resultHS = FromPolar(new PolarPoint( (float)radiusHS, (float)angleHS) );
             resultHS.X  += canvasRadius;
@@ -173,12 +173,12 @@ public class ColorDisc : SkiaPickerBase
             _locationHS   = resultHS;
         }
 
-        var polarL      = ToPolar(ToWheelLCoordinates(_locationL, canvasRadius));
+        var polarL      = ToPolar(ToLCoordinates(_locationL, canvasRadius));
         polarL.Angle   -= (float)Math.PI / 2F;
         var signOld     = polarL.Angle <= 0 ? 1 : -1;
         var angleL      = color.GetLuminosity() * Math.PI * signOld;
 
-        var resultL     = FromPolar( new PolarPoint( WheelLRadius(canvasRadius), (float)(angleL - (Math.PI / 2)) ) );
+        var resultL     = FromPolar( new PolarPoint( LRadius(canvasRadius), (float)(angleL - (Math.PI / 2)) ) );
         resultL.X      += canvasRadius;
         resultL.Y      += canvasRadius;
         _locationL       = resultL;
@@ -186,17 +186,17 @@ public class ColorDisc : SkiaPickerBase
 
     void UpdateColors( float canvasRadius )
     {
-        var wheelHSPoint    = ToWheelHSCoordinates(_locationHS, canvasRadius);
-        var wheelLPoint     = ToWheelLCoordinates(_locationL, canvasRadius);
+        var hsPoint    = ToHsCoordinates(_locationHS, canvasRadius);
+        var lPoint     = ToLCoordinates(_locationL, canvasRadius);
 
-        var newColor        = WheelPointToColor(wheelHSPoint, wheelLPoint);
+        var newColor        = WheelPointToColor(hsPoint, lPoint);
         SelectedColor       = newColor;
     }
 
     bool IsInHSArea( SKPoint point, float canvasRadius )
     {
         var polar = ToPolar( new SKPoint( point.X - canvasRadius, point.Y - canvasRadius ) );
-        return polar.Radius <= WheelHSRadius( canvasRadius );
+        return polar.Radius <= HsRadius( canvasRadius );
     }
 
     bool IsInLArea( SKPoint point, float canvasRadius )
@@ -206,8 +206,8 @@ public class ColorDisc : SkiaPickerBase
 
         var polar = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
 
-        return polar.Radius <= WheelLRadius( canvasRadius ) + ( GetIndicatorRadiusPixels() / 2F )
-            && polar.Radius >= WheelLRadius( canvasRadius ) - ( GetIndicatorRadiusPixels() / 2F );
+        return polar.Radius <= LRadius( canvasRadius ) + ( GetIndicatorRadiusPixels() / 2F )
+            && polar.Radius >= LRadius( canvasRadius ) - ( GetIndicatorRadiusPixels() / 2F );
     }
 
     void PaintBackground( SKCanvas canvas, float canvasRadius )
@@ -245,7 +245,7 @@ public class ColorDisc : SkiaPickerBase
             Style       = SKPaintStyle.Stroke,
             StrokeWidth = GetIndicatorRadiusPixels()
         };
-        canvas.DrawCircle( center, WheelLRadius( canvasRadius ), paint );
+        canvas.DrawCircle( center, LRadius( canvasRadius ), paint );
     }
 
     void PaintColorSweepGradient( SKCanvas canvas, float canvasRadius )
@@ -260,7 +260,7 @@ public class ColorDisc : SkiaPickerBase
             Shader      = shader,
             Style       = SKPaintStyle.Fill
         };
-        canvas.DrawCircle( center, WheelHSRadius( canvasRadius ), paint );
+        canvas.DrawCircle( center, HsRadius( canvasRadius ), paint );
     }
 
     void PaintGrayRadialGradient( SKCanvas canvas, float canvasRadius )
@@ -273,7 +273,7 @@ public class ColorDisc : SkiaPickerBase
             SKColors.Transparent
         };
 
-        var shader = SKShader.CreateRadialGradient( center, WheelHSRadius(canvasRadius), colors, null, SKShaderTileMode.Clamp );
+        var shader = SKShader.CreateRadialGradient( center, HsRadius(canvasRadius), colors, null, SKShaderTileMode.Clamp );
 
         var paint = new SKPaint
         {
@@ -284,26 +284,26 @@ public class ColorDisc : SkiaPickerBase
         canvas.DrawPaint( paint );
     }
 
-    SKPoint ToWheelHSCoordinates( SKPoint point, float canvasRadius )
+    SKPoint ToHsCoordinates( SKPoint point, float canvasRadius )
     {
         var result = new SKPoint( point.X, point.Y );
 
         result.X  -= canvasRadius;
         result.Y  -= canvasRadius;
-        result.X  /= WheelHSRadius( canvasRadius );
-        result.Y  /= WheelHSRadius( canvasRadius );
+        result.X  /= HsRadius( canvasRadius );
+        result.Y  /= HsRadius( canvasRadius );
 
         return result;
     }
 
-    SKPoint ToWheelLCoordinates( SKPoint point, float canvasRadius )
+    SKPoint ToLCoordinates( SKPoint point, float canvasRadius )
     {
         var result = new SKPoint( point.X, point.Y );
 
         result.X  -= canvasRadius;
         result.Y  -= canvasRadius;
-        result.X  /= WheelLRadius( canvasRadius );
-        result.Y  /= WheelLRadius( canvasRadius );
+        result.X  /= LRadius( canvasRadius );
+        result.Y  /= LRadius( canvasRadius );
 
         return result;
     }
@@ -326,7 +326,7 @@ public class ColorDisc : SkiaPickerBase
     SKPoint LimitToHSRadius( SKPoint point, float canvasRadius )
     {
         var polar       = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
-        polar.Radius    = polar.Radius < WheelHSRadius( canvasRadius ) ? polar.Radius : WheelHSRadius( canvasRadius );
+        polar.Radius    = polar.Radius < HsRadius( canvasRadius ) ? polar.Radius : HsRadius( canvasRadius );
         var result      = FromPolar(polar);
 
         result.X       += canvasRadius;
@@ -338,7 +338,7 @@ public class ColorDisc : SkiaPickerBase
     SKPoint LimitToLRadius( SKPoint point, float canvasRadius )
     {
         var polar       = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
-        polar.Radius    = WheelLRadius( canvasRadius );
+        polar.Radius    = LRadius( canvasRadius );
         var result      = FromPolar(polar);
 
         result.X       += canvasRadius;
@@ -367,10 +367,10 @@ public class ColorDisc : SkiaPickerBase
     // does not get clipped at the canvas edge.
     const float PickerEdgeMargin = 3F;
 
-    float WheelHSRadius( float canvasRadius )
+    float HsRadius( float canvasRadius )
        => ! ShowLuminosityRing ? canvasRadius - GetIndicatorRadiusPixels() - PickerEdgeMargin
                                 : canvasRadius - ( 3 * GetIndicatorRadiusPixels() ) - 2;
 
-    float WheelLRadius( float canvasRadius )
+    float LRadius( float canvasRadius )
        => canvasRadius - GetIndicatorRadiusPixels() - PickerEdgeMargin;
 }

--- a/ColorPicker/Controls/ColorTriangle.cs
+++ b/ColorPicker/Controls/ColorTriangle.cs
@@ -208,7 +208,7 @@ public class ColorTriangle : SkiaPickerBase
 
     void UpdateLocations( Color color, float canvasRadius )
     {
-        ColorToHSV( color, out _, out var saturation, out var value );
+        ColorToHsv( color, out _, out var saturation, out var value );
 
         var luminosityX = -(float)( (2 * _triangleSide * saturation) - _triangleSide );
         var luminosityY = _triangleHeight;
@@ -219,8 +219,8 @@ public class ColorTriangle : SkiaPickerBase
         _locationSV = FromPolar( polarValue );
         _locationSV.X = -_locationSV.X;
         _locationSV.Y -= 1;
-        _locationSV.X *= WheelSVRadius( canvasRadius );
-        _locationSV.Y *= WheelSVRadius( canvasRadius );
+        _locationSV.X *= SvRadius( canvasRadius );
+        _locationSV.Y *= SvRadius( canvasRadius );
 
         polarValue = ToPolar( new SKPoint( _locationSV.X, _locationSV.Y ) );
         polarValue.Angle -= (float)(2 * Math.PI / 3);
@@ -237,24 +237,24 @@ public class ColorTriangle : SkiaPickerBase
 
         var angleH = _lastHue * Math.PI * 2;
 
-        _locationMiddleH = FromPolar( new PolarPoint( WheelHRadius( canvasRadius ), (float)(Math.PI - angleH) ) );
+        _locationMiddleH = FromPolar( new PolarPoint( HRadius( canvasRadius ), (float)(Math.PI - angleH) ) );
         _locationMiddleH.X += canvasRadius;
         _locationMiddleH.Y += canvasRadius;
 
-        _locationH1 = FromPolar( new PolarPoint( WheelHRadius( canvasRadius ) + GetIndicatorRadiusPixels(), (float)(Math.PI - angleH) ) );
+        _locationH1 = FromPolar( new PolarPoint( HRadius( canvasRadius ) + GetIndicatorRadiusPixels(), (float)(Math.PI - angleH) ) );
         _locationH1.X += canvasRadius;
         _locationH1.Y += canvasRadius;
 
-        _locationH2 = FromPolar( new PolarPoint( WheelHRadius( canvasRadius ) - GetIndicatorRadiusPixels(), (float)(Math.PI - angleH) ) );
+        _locationH2 = FromPolar( new PolarPoint( HRadius( canvasRadius ) - GetIndicatorRadiusPixels(), (float)(Math.PI - angleH) ) );
         _locationH2.X += canvasRadius;
         _locationH2.Y += canvasRadius;
     }
 
     void UpdateColors( float canvasRadius )
     {
-        var wheelSVPoint = ToWheelSVCoordinates(_locationSV, canvasRadius);
-        var wheelHPoint = ToWheelHCoordinates(_locationH1, canvasRadius);
-        var newColor = WheelPointToColor(wheelSVPoint, wheelHPoint);
+        var svPoint = ToSvCoordinates(_locationSV, canvasRadius);
+        var hPoint = ToHCoordinates(_locationH1, canvasRadius);
+        var newColor = WheelPointToColor(svPoint, hPoint);
 
         if (_zeroSL && (newColor.GetSaturation() > 0))
         {
@@ -267,13 +267,13 @@ public class ColorTriangle : SkiaPickerBase
     bool IsInSVArea( SKPoint point, float canvasRadius )
     {
         var polar = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
-        return polar.Radius <= WheelSVRadius( canvasRadius );
+        return polar.Radius <= SvRadius( canvasRadius );
     }
 
     bool IsInHArea( SKPoint point, float canvasRadius )
     {
         var polar = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
-        return polar.Radius <= WheelHRadius( canvasRadius ) + GetIndicatorRadiusPixels() && polar.Radius >= WheelHRadius( canvasRadius ) - GetIndicatorRadiusPixels();
+        return polar.Radius <= HRadius( canvasRadius ) + GetIndicatorRadiusPixels() && polar.Radius >= HRadius( canvasRadius ) - GetIndicatorRadiusPixels();
     }
 
     void PaintBackground( SKCanvas canvas, float canvasRadius )
@@ -300,7 +300,7 @@ public class ColorTriangle : SkiaPickerBase
             Style = SKPaintStyle.Stroke,
             StrokeWidth = GetIndicatorRadiusPixels() * 2
         };
-        canvas.DrawCircle( center, WheelHRadius( canvasRadius ), paint );
+        canvas.DrawCircle( center, HRadius( canvasRadius ), paint );
     }
 
     void PaintSVTriangle( SKCanvas canvas, float canvasRadius )
@@ -315,12 +315,12 @@ public class ColorTriangle : SkiaPickerBase
             canvas.Concat( ref rotationHue );
         }
 
-        var point1 = new SKPoint( canvasRadius, canvasRadius - WheelSVRadius(canvasRadius) );
-        var point2 = new SKPoint(canvasRadius + (_triangleSide * WheelSVRadius(canvasRadius))
-                , canvasRadius + (_triangleVerticalOffset * WheelSVRadius(canvasRadius)));
+        var point1 = new SKPoint( canvasRadius, canvasRadius - SvRadius(canvasRadius) );
+        var point2 = new SKPoint(canvasRadius + (_triangleSide * SvRadius(canvasRadius))
+                , canvasRadius + (_triangleVerticalOffset * SvRadius(canvasRadius)));
 
-        var point3 = new SKPoint(canvasRadius - (_triangleSide * WheelSVRadius(canvasRadius))
-                , canvasRadius + (_triangleVerticalOffset * WheelSVRadius(canvasRadius)));
+        var point3 = new SKPoint(canvasRadius - (_triangleSide * SvRadius(canvasRadius))
+                , canvasRadius + (_triangleVerticalOffset * SvRadius(canvasRadius)));
 
         using (var pathTriangle = new SKPath())
         {
@@ -355,7 +355,7 @@ public class ColorTriangle : SkiaPickerBase
             Style       = SKPaintStyle.Fill
         };
 
-        canvas.DrawCircle( point3, WheelSVRadius( canvasRadius ) * 2, paint );
+        canvas.DrawCircle( point3, SvRadius( canvasRadius ) * 2, paint );
 
         canvas.Restore();
 
@@ -390,29 +390,29 @@ public class ColorTriangle : SkiaPickerBase
             Style       = SKPaintStyle.Fill
         };
 
-        canvas.DrawCircle( center, WheelSVRadius( canvasRadius ), paint );
+        canvas.DrawCircle( center, SvRadius( canvasRadius ), paint );
     }
 
-    SKPoint ToWheelSVCoordinates( SKPoint point, float canvasRadius )
+    SKPoint ToSvCoordinates( SKPoint point, float canvasRadius )
     {
         var result = new SKPoint(point.X, point.Y);
 
         result.X -= canvasRadius;
         result.Y -= canvasRadius;
-        result.X /= WheelSVRadius( canvasRadius );
-        result.Y /= WheelSVRadius( canvasRadius );
+        result.X /= SvRadius( canvasRadius );
+        result.Y /= SvRadius( canvasRadius );
 
         return result;
     }
 
-    SKPoint ToWheelHCoordinates( SKPoint point, float canvasRadius )
+    SKPoint ToHCoordinates( SKPoint point, float canvasRadius )
     {
         var result = new SKPoint(point.X, point.Y);
 
         result.X -= canvasRadius;
         result.Y -= canvasRadius;
-        result.X /= WheelHRadius( canvasRadius );
-        result.Y /= WheelHRadius( canvasRadius );
+        result.X /= HRadius( canvasRadius );
+        result.Y /= HRadius( canvasRadius );
 
         return result;
     }
@@ -448,7 +448,7 @@ public class ColorTriangle : SkiaPickerBase
         var s = sCurrent / sMax;
 
         _lastHue = h;
-        var result = ColorFromHSV(h, s, v, SelectedColor.Alpha);
+        var result = ColorFromHsv(h, s, v, SelectedColor.Alpha);
 
         return result;
     }
@@ -456,7 +456,7 @@ public class ColorTriangle : SkiaPickerBase
     SKPoint LimitToSVTriangle( SKPoint point, float canvasRadius )
     {
         var polar = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
-        polar.Radius = polar.Radius < WheelSVRadius( canvasRadius ) ? polar.Radius : WheelSVRadius( canvasRadius );
+        polar.Radius = polar.Radius < SvRadius( canvasRadius ) ? polar.Radius : SvRadius( canvasRadius );
 
         var result = FromPolar(polar);
         result.X += canvasRadius;
@@ -467,10 +467,10 @@ public class ColorTriangle : SkiaPickerBase
     void LimitToHRadius( SKPoint point, float canvasRadius )
     {
         var point1 = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
-        point1.Radius = WheelHRadius( canvasRadius ) + GetIndicatorRadiusPixels();
+        point1.Radius = HRadius( canvasRadius ) + GetIndicatorRadiusPixels();
 
         var point2 = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
-        point1.Radius = WheelHRadius( canvasRadius ) - GetIndicatorRadiusPixels();
+        point1.Radius = HRadius( canvasRadius ) - GetIndicatorRadiusPixels();
 
         _locationH1 = FromPolar( point1 );
         _locationH2 = FromPolar( point2 );
@@ -495,8 +495,8 @@ public class ColorTriangle : SkiaPickerBase
         return new SKPoint( x, y );
     }
 
-    float WheelSVRadius( float canvasRadius ) => canvasRadius - (2 * GetIndicatorRadiusPixels()) - 2;
-    float WheelHRadius( float canvasRadius ) => canvasRadius - GetIndicatorRadiusPixels();
+    float SvRadius( float canvasRadius ) => canvasRadius - (2 * GetIndicatorRadiusPixels()) - 2;
+    float HRadius( float canvasRadius ) => canvasRadius - GetIndicatorRadiusPixels();
 
     void PaintLinePicker( SKCanvas canvas )
     {
@@ -516,7 +516,7 @@ public class ColorTriangle : SkiaPickerBase
         canvas.DrawPath( pathTriangle, paint );
     }
 
-    public static void ColorToHSV( Color color, out double hue, out double saturation, out double value )
+    public static void ColorToHsv( Color color, out double hue, out double saturation, out double value )
     {
         var rgb = new Rgb { R = Math.Round(color.Red * 255F), G = Math.Round(color.Green * 255F), B = Math.Round(color.Blue * 255F) };
         var hsv = rgb.To<Hsv>();
@@ -526,7 +526,7 @@ public class ColorTriangle : SkiaPickerBase
         value = hsv.V;
     }
 
-    public static Color ColorFromHSV( double hue, double saturation, double value, double a )
+    public static Color ColorFromHsv( double hue, double saturation, double value, double a )
     {
         var result = Color.FromHsv((float)hue, (float)saturation, (float)value);
         return new Color( result.Red, result.Green, result.Blue, (float)a );


### PR DESCRIPTION
Deeper naming pass (Tier 4) — internal helpers and HSV casing.

## Renames

**`ColorDisc`** (private helpers):
- `WheelHSRadius` → `HsRadius`
- `WheelLRadius` → `LRadius`
- `ToWheelHSCoordinates` → `ToHsCoordinates`
- `ToWheelLCoordinates` → `ToLCoordinates`
- locals `wheelHSPoint` / `wheelLPoint` → `hsPoint` / `lPoint`

**`ColorTriangle`** (private helpers):
- `WheelSVRadius` → `SvRadius`
- `WheelHRadius` → `HRadius`
- `ToWheelSVCoordinates` → `ToSvCoordinates`
- `ToWheelHCoordinates` → `ToHCoordinates`
- locals `wheelSVPoint` / `wheelHPoint` → `svPoint` / `hPoint`

**`ColorTriangle`** (public statics — casing only, matches Hsl/Rgb convention from #21):
- `ColorToHSV` → `ColorToHsv`
- `ColorFromHSV` → `ColorFromHsv`

## Rationale

The `Wheel*` prefix is a leftover from when `ColorDisc` was called `ColorCircle` and lived inside the wheel composite. Neither `ColorDisc` nor `ColorTriangle` is itself a wheel — only the `ColorWheel` composite is, and it delegates to `ColorDisc`. Stripping the prefix makes the geometry helpers read accurately.

`ColorToHSV`/`ColorFromHSV` are the last HSL-style acronyms not yet normalized.

## Scope

- 2 files changed, 55 insertions / 55 deletions — pure rename, no behavior change.
- All renamed members were either `private` or `public static` with no external callers in the test app, UI tests, or consumer smoke.

🟡 **Not for auto-merge.** Waiting on owner approval per request.