### PR TITLE
refactor: finish HS/SV -> Hs/Sv normalization + drop Xamarin.Forms refs

### DIFF
--- a/ColorPicker/Controls/ColorDisc.cs
+++ b/ColorPicker/Controls/ColorDisc.cs
@@ -2,10 +2,10 @@ namespace ColorPicker.Controls;
 
 public class ColorDisc : SkiaPickerBase
 {
-    long?   _locationHSProgressId    = null;
+    long?   _locationHsProgressId    = null;
     long?   _locationLProgressId     = null;
 
-    SKPoint _locationHS              = new();
+    SKPoint _locationHs              = new();
     SKPoint _locationL               = new();
 
     readonly SKColor[] _sweepGradientColors = new SKColor[256];
@@ -63,10 +63,10 @@ public class ColorDisc : SkiaPickerBase
         var canvasRadius    = GetCanvasSize().Width / 2F;
         var point           = ConvertToPixel(args.Location);
 
-        if ( _locationHSProgressId is null && IsInHSArea( point, canvasRadius ) )
+        if ( _locationHsProgressId is null && IsInHsArea( point, canvasRadius ) )
         {
-            _locationHSProgressId    = args.Id;
-            _locationHS              = LimitToHSRadius( point, canvasRadius );
+            _locationHsProgressId    = args.Id;
+            _locationHs              = LimitToHsRadius( point, canvasRadius );
             UpdateColors( canvasRadius );
         }
         else if ( _locationLProgressId is null && IsInLArea( point, canvasRadius ) )
@@ -82,9 +82,9 @@ public class ColorDisc : SkiaPickerBase
         var canvasRadius    = GetCanvasSize().Width / 2F;
         var point           = ConvertToPixel(args.Location);
 
-        if ( _locationHSProgressId == args.Id )
+        if ( _locationHsProgressId == args.Id )
         {
-            _locationHS = LimitToHSRadius( point, canvasRadius );
+            _locationHs = LimitToHsRadius( point, canvasRadius );
             UpdateColors( canvasRadius );
         }
         else if ( _locationLProgressId == args.Id )
@@ -99,10 +99,10 @@ public class ColorDisc : SkiaPickerBase
         var canvasRadius    = GetCanvasSize().Width / 2F;
         var point           = ConvertToPixel(args.Location);
 
-        if ( _locationHSProgressId == args.Id )
+        if ( _locationHsProgressId == args.Id )
         {
-            _locationHSProgressId    = null;
-            _locationHS              = LimitToHSRadius( point, canvasRadius );
+            _locationHsProgressId    = null;
+            _locationHs              = LimitToHsRadius( point, canvasRadius );
             UpdateColors( canvasRadius );
         }
         else if ( _locationLProgressId == args.Id )
@@ -115,8 +115,8 @@ public class ColorDisc : SkiaPickerBase
 
     protected override void OnTouchActionCancelled( TouchActionEventArgs args )
     {
-        if ( _locationHSProgressId == args.Id )
-            _locationHSProgressId = null;
+        if ( _locationHsProgressId == args.Id )
+            _locationHsProgressId = null;
         else if ( _locationLProgressId == args.Id )
             _locationLProgressId = null;
     }
@@ -137,7 +137,7 @@ public class ColorDisc : SkiaPickerBase
 
         PaintColorSweepGradient( canvas, canvasRadius );
         PaintGrayRadialGradient( canvas, canvasRadius );
-        PaintIndicator( canvas, _locationHS );
+        PaintIndicator( canvas, _locationHs );
     }
 
     protected override void OnSelectedColorChanging( Color color ) 
@@ -162,15 +162,15 @@ public class ColorDisc : SkiaPickerBase
 
     void UpdateLocations( Color color, float canvasRadius )
     {
-        if ( color.GetLuminosity() != 0 || !IsInHSArea( _locationHS, canvasRadius ) )
+        if ( color.GetLuminosity() != 0 || !IsInHsArea( _locationHs, canvasRadius ) )
         {
-            var angleHS  = (0.5 - color.GetHue()) * (2 * Math.PI);
-            var radiusHS = HsRadius(canvasRadius) * color.GetSaturation();
+            var angleHs  = (0.5 - color.GetHue()) * (2 * Math.PI);
+            var radiusHs = HsRadius(canvasRadius) * color.GetSaturation();
 
-            var resultHS = FromPolar(new PolarPoint( (float)radiusHS, (float)angleHS) );
-            resultHS.X  += canvasRadius;
-            resultHS.Y  += canvasRadius;
-            _locationHS   = resultHS;
+            var resultHs = FromPolar(new PolarPoint( (float)radiusHs, (float)angleHs) );
+            resultHs.X  += canvasRadius;
+            resultHs.Y  += canvasRadius;
+            _locationHs   = resultHs;
         }
 
         var polarL      = ToPolar(ToLCoordinates(_locationL, canvasRadius));
@@ -186,14 +186,14 @@ public class ColorDisc : SkiaPickerBase
 
     void UpdateColors( float canvasRadius )
     {
-        var hsPoint    = ToHsCoordinates(_locationHS, canvasRadius);
+        var hsPoint    = ToHsCoordinates(_locationHs, canvasRadius);
         var lPoint     = ToLCoordinates(_locationL, canvasRadius);
 
         var newColor        = WheelPointToColor(hsPoint, lPoint);
         SelectedColor       = newColor;
     }
 
-    bool IsInHSArea( SKPoint point, float canvasRadius )
+    bool IsInHsArea( SKPoint point, float canvasRadius )
     {
         var polar = ToPolar( new SKPoint( point.X - canvasRadius, point.Y - canvasRadius ) );
         return polar.Radius <= HsRadius( canvasRadius );
@@ -323,7 +323,7 @@ public class ColorDisc : SkiaPickerBase
         return Color.FromHsla( h, s, l, SelectedColor.Alpha );
     }
 
-    SKPoint LimitToHSRadius( SKPoint point, float canvasRadius )
+    SKPoint LimitToHsRadius( SKPoint point, float canvasRadius )
     {
         var polar       = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
         polar.Radius    = polar.Radius < HsRadius( canvasRadius ) ? polar.Radius : HsRadius( canvasRadius );

--- a/ColorPicker/Controls/ColorTriangle.cs
+++ b/ColorPicker/Controls/ColorTriangle.cs
@@ -4,9 +4,9 @@ public class ColorTriangle : SkiaPickerBase
 {
     double _lastHue = 0;
     bool _zeroSL = false;
-    long? _locationSVProgressId = null;
+    long? _locationSvProgressId = null;
     long? _locationHProgressId = null;
-    SKPoint _locationSV = new();
+    SKPoint _locationSv = new();
     SKPoint _locationH1 = new();
     SKPoint _locationH2 = new();
     SKPoint _locationMiddleH = new();
@@ -78,10 +78,10 @@ public class ColorTriangle : SkiaPickerBase
         point.X -= offX;
         point.Y -= offY;
 
-        if (_locationSVProgressId is null && IsInSVArea( point, canvasRadius ))
+        if (_locationSvProgressId is null && IsInSvArea( point, canvasRadius ))
         {
-            _locationSVProgressId = args.Id;
-            _locationSV = LimitToSVTriangle( point, canvasRadius );
+            _locationSvProgressId = args.Id;
+            _locationSv = LimitToSvTriangle( point, canvasRadius );
             UpdateColors( canvasRadius );
         }
         else if (_locationHProgressId is null && IsInHArea( point, canvasRadius ))
@@ -100,9 +100,9 @@ public class ColorTriangle : SkiaPickerBase
         point.X -= offX;
         point.Y -= offY;
 
-        if (_locationSVProgressId == args.Id)
+        if (_locationSvProgressId == args.Id)
         {
-            _locationSV = LimitToSVTriangle( point, canvasRadius );
+            _locationSv = LimitToSvTriangle( point, canvasRadius );
             UpdateColors( canvasRadius );
         }
         else if (_locationHProgressId == args.Id)
@@ -120,10 +120,10 @@ public class ColorTriangle : SkiaPickerBase
         point.X -= offX;
         point.Y -= offY;
 
-        if (_locationSVProgressId == args.Id)
+        if (_locationSvProgressId == args.Id)
         {
-            _locationSVProgressId = null;
-            _locationSV = LimitToSVTriangle( point, canvasRadius );
+            _locationSvProgressId = null;
+            _locationSv = LimitToSvTriangle( point, canvasRadius );
             UpdateColors( canvasRadius );
         }
         else if (_locationHProgressId == args.Id)
@@ -136,8 +136,8 @@ public class ColorTriangle : SkiaPickerBase
 
     protected override void OnTouchActionCancelled( TouchActionEventArgs args )
     {
-        if (_locationSVProgressId == args.Id)
-            _locationSVProgressId = null;
+        if (_locationSvProgressId == args.Id)
+            _locationSvProgressId = null;
         else if (_locationHProgressId == args.Id)
             _locationHProgressId = null;
     }
@@ -161,8 +161,8 @@ public class ColorTriangle : SkiaPickerBase
         else
             PaintIndicator( canvas, _locationMiddleH );
 
-        PaintSVTriangle( canvas, canvasRadius );
-        PaintIndicator( canvas, _locationSV );
+        PaintSvTriangle( canvas, canvasRadius );
+        PaintIndicator( canvas, _locationSv );
 
         canvas.Restore();
     }
@@ -216,23 +216,23 @@ public class ColorTriangle : SkiaPickerBase
         var polarValue = ToPolar(new SKPoint(luminosityX, luminosityY));
         polarValue.Radius *= (float)value;
 
-        _locationSV = FromPolar( polarValue );
-        _locationSV.X = -_locationSV.X;
-        _locationSV.Y -= 1;
-        _locationSV.X *= SvRadius( canvasRadius );
-        _locationSV.Y *= SvRadius( canvasRadius );
+        _locationSv = FromPolar( polarValue );
+        _locationSv.X = -_locationSv.X;
+        _locationSv.Y -= 1;
+        _locationSv.X *= SvRadius( canvasRadius );
+        _locationSv.Y *= SvRadius( canvasRadius );
 
-        polarValue = ToPolar( new SKPoint( _locationSV.X, _locationSV.Y ) );
+        polarValue = ToPolar( new SKPoint( _locationSv.X, _locationSv.Y ) );
         polarValue.Angle -= (float)(2 * Math.PI / 3);
-        _locationSV = FromPolar( polarValue );
+        _locationSv = FromPolar( polarValue );
 
-        _locationSV.X += canvasRadius;
-        _locationSV.Y += canvasRadius;
+        _locationSv.X += canvasRadius;
+        _locationSv.Y += canvasRadius;
 
         if (RotateTriangleByHue)
         {
             var rotationHue = SKMatrix.CreateRotation(-(float)((2D * Math.PI * _lastHue) + (Math.PI / 2D)), canvasRadius, canvasRadius);
-            _locationSV = rotationHue.MapPoint( _locationSV );
+            _locationSv = rotationHue.MapPoint( _locationSv );
         }
 
         var angleH = _lastHue * Math.PI * 2;
@@ -252,7 +252,7 @@ public class ColorTriangle : SkiaPickerBase
 
     void UpdateColors( float canvasRadius )
     {
-        var svPoint = ToSvCoordinates(_locationSV, canvasRadius);
+        var svPoint = ToSvCoordinates(_locationSv, canvasRadius);
         var hPoint = ToHCoordinates(_locationH1, canvasRadius);
         var newColor = WheelPointToColor(svPoint, hPoint);
 
@@ -264,7 +264,7 @@ public class ColorTriangle : SkiaPickerBase
         SelectedColor = newColor;
     }
 
-    bool IsInSVArea( SKPoint point, float canvasRadius )
+    bool IsInSvArea( SKPoint point, float canvasRadius )
     {
         var polar = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
         return polar.Radius <= SvRadius( canvasRadius );
@@ -303,7 +303,7 @@ public class ColorTriangle : SkiaPickerBase
         canvas.DrawCircle( center, HRadius( canvasRadius ), paint );
     }
 
-    void PaintSVTriangle( SKCanvas canvas, float canvasRadius )
+    void PaintSvTriangle( SKCanvas canvas, float canvasRadius )
     {
         canvas.Save();
 
@@ -453,7 +453,7 @@ public class ColorTriangle : SkiaPickerBase
         return result;
     }
 
-    SKPoint LimitToSVTriangle( SKPoint point, float canvasRadius )
+    SKPoint LimitToSvTriangle( SKPoint point, float canvasRadius )
     {
         var polar = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
         polar.Radius = polar.Radius < SvRadius( canvasRadius ) ? polar.Radius : SvRadius( canvasRadius );

--- a/ColorPicker/Platforms/MacCatalyst/IosTouchRecognizer.cs
+++ b/ColorPicker/Platforms/MacCatalyst/IosTouchRecognizer.cs
@@ -153,7 +153,7 @@ namespace ColorPicker.iOS.Effects
 
         void FireEvent(ColorPickerTouchRecognizer recognizer, long id, TouchActionType actionType, UITouch touch, bool isInContact)
         {
-            // Convert touch location to Xamarin.Forms Point value
+            // Convert touch location to MAUI Point value
             CGPoint cgPoint = touch.LocationInView(recognizer.View);
             Point xfPoint = new Point(cgPoint.X, cgPoint.Y);
 

--- a/ColorPicker/Platforms/iOS/IosTouchRecognizer.cs
+++ b/ColorPicker/Platforms/iOS/IosTouchRecognizer.cs
@@ -153,7 +153,7 @@ namespace ColorPicker.iOS.Effects
 
         void FireEvent(ColorPickerTouchRecognizer recognizer, long id, TouchActionType actionType, UITouch touch, bool isInContact)
         {
-            // Convert touch location to Xamarin.Forms Point value
+            // Convert touch location to MAUI Point value
             CGPoint cgPoint = touch.LocationInView(recognizer.View);
             Point xfPoint = new Point(cgPoint.X, cgPoint.Y);
 


### PR DESCRIPTION
Followup to #22. Same convention applied to the matching private fields and helpers I missed:

- _locationHS / _locationSV -> _locationHs / _locationSv
- _locationHSProgressId / _locationSVProgressId -> _locationHsProgressId / _locationSvProgressId
- IsInHSArea / IsInSVArea -> IsInHsArea / IsInSvArea
- LimitToHSRadius / LimitToSVTriangle -> LimitToHsRadius / LimitToSvTriangle
- locals: `resultHS` / `radiusHS` / `angleHS` -> `resultHs` / `radiusHs` / `angleHs`

Plus two stale `// Convert touch location to Xamarin.Forms Point value` comments in `Platforms/iOS/IosTouchRecognizer.cs` and `Platforms/MacCatalyst/IosTouchRecognizer.cs` updated to `MAUI Point value`.

All private, no API surface change. `L` / `H1` / `H2` / `MiddleH` single-letter names left alone.