### PR TITLE
chore: normalize formatting to mainstream .NET conventions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,7 +18,7 @@ insert_final_newline = true
 #### .NET Coding Conventions ####
 
 # Organize usings
-dotnet_separate_import_directive_groups = true
+dotnet_separate_import_directive_groups = false
 dotnet_sort_system_directives_first = true
 file_header_template = unset
 
@@ -124,12 +124,12 @@ csharp_style_unused_value_assignment_preference = discard_variable:silent
 csharp_style_unused_value_expression_statement_preference = discard_variable:silent
 
 # 'using' directive preferences
-csharp_using_directive_placement = inside_namespace:suggestion
+csharp_using_directive_placement = outside_namespace:suggestion
 
 # New line preferences
 csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true:suggestion
 csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false:suggestion
-csharp_style_allow_embedded_statements_on_same_line_experimental = true:suggestion
+csharp_style_allow_embedded_statements_on_same_line_experimental = false:suggestion
 
 #### C# Formatting Rules ####
 
@@ -147,7 +147,7 @@ csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents = true
 csharp_indent_case_contents_when_block = false
-csharp_indent_labels = flush_left 
+csharp_indent_labels = one_less_than_current
 csharp_indent_switch_labels = true
 
 # Space preferences
@@ -167,12 +167,12 @@ csharp_space_before_semicolon_in_for_statement = false
 csharp_space_between_empty_square_brackets = false
 csharp_space_between_method_call_empty_parameter_list_parentheses = false
 csharp_space_between_method_call_name_and_opening_parenthesis = false
-csharp_space_between_method_call_parameter_list_parentheses = true
+csharp_space_between_method_call_parameter_list_parentheses = false
 csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
 csharp_space_between_method_declaration_name_and_open_parenthesis = false
-csharp_space_between_method_declaration_parameter_list_parentheses = true
-csharp_space_between_parentheses = control_flow_statements,expressions
-csharp_space_between_square_brackets = true
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
 
 # Wrapping preferences
 csharp_preserve_single_line_blocks = true

--- a/ColorPicker.UITests/Infrastructure/PixelImage.cs
+++ b/ColorPicker.UITests/Infrastructure/PixelImage.cs
@@ -30,7 +30,7 @@ public sealed class PixelImage : IDisposable
 
     private PixelImage(SKBitmap bitmap) => _bitmap = bitmap;
 
-    public int Width  => _bitmap.Width;
+    public int Width => _bitmap.Width;
     public int Height => _bitmap.Height;
 
     /// <summary>RGBA read of the pixel at (x, y). No bounds checking —
@@ -66,7 +66,7 @@ public sealed class PixelImage : IDisposable
     {
         x = Math.Max(0, x);
         y = Math.Max(0, y);
-        w = Math.Min(w, _bitmap.Width  - x);
+        w = Math.Min(w, _bitmap.Width - x);
         h = Math.Min(h, _bitmap.Height - y);
 
         var dst = new SKBitmap(w, h, _bitmap.ColorType, _bitmap.AlphaType);

--- a/ColorPicker.UITests/Infrastructure/ReferenceImage.cs
+++ b/ColorPicker.UITests/Infrastructure/ReferenceImage.cs
@@ -63,14 +63,14 @@ public static class ReferenceImage
         long bad = 0;
         long total = (long)a.Width * a.Height;
         for (int y = 0; y < a.Height; y++)
-        for (int x = 0; x < a.Width;  x++)
-        {
-            var pa = a[x, y]; var pb = b[x, y];
-            int d = Math.Abs(pa.R - pb.R)
+            for (int x = 0; x < a.Width; x++)
+            {
+                var pa = a[x, y]; var pb = b[x, y];
+                int d = Math.Abs(pa.R - pb.R)
                   + Math.Abs(pa.G - pb.G)
                   + Math.Abs(pa.B - pb.B);
-            if (d > perPixelTol) bad++;
-        }
+                if (d > perPixelTol) bad++;
+            }
         return bad / (double)total;
     }
 

--- a/ColorPicker.UITests/Infrastructure/Screenshot.cs
+++ b/ColorPicker.UITests/Infrastructure/Screenshot.cs
@@ -50,13 +50,13 @@ public static class Screenshot
         int half = size / 2;
         long r = 0, g = 0, b = 0, a = 0, n = 0;
         for (int dy = -half; dy <= half; dy++)
-        for (int dx = -half; dx <= half; dx++)
-        {
-            int x = cx + dx, y = cy + dy;
-            if (x < 0 || y < 0 || x >= img.Width || y >= img.Height) continue;
-            var p = img[x, y];
-            r += p.R; g += p.G; b += p.B; a += p.A; n++;
-        }
+            for (int dx = -half; dx <= half; dx++)
+            {
+                int x = cx + dx, y = cy + dy;
+                if (x < 0 || y < 0 || x >= img.Width || y >= img.Height) continue;
+                var p = img[x, y];
+                r += p.R; g += p.G; b += p.B; a += p.A; n++;
+            }
         if (n == 0) return new Pixel(0, 0, 0, 0);
         return new Pixel((byte)(r / n), (byte)(g / n), (byte)(b / n), (byte)(a / n));
     }
@@ -67,8 +67,8 @@ public static class Screenshot
 
 public readonly record struct PixelRect(int X, int Y, int W, int H, double DpiScale)
 {
-    public int Right   => X + W;
-    public int Bottom  => Y + H;
+    public int Right => X + W;
+    public int Bottom => Y + H;
     public int CenterX => X + W / 2;
     public int CenterY => Y + H / 2;
 

--- a/ColorPicker.UITests/Infrastructure/SyncTestAppFixture.cs
+++ b/ColorPicker.UITests/Infrastructure/SyncTestAppFixture.cs
@@ -18,7 +18,7 @@ public sealed class SyncTestAppFixture : AppFixtureBase
     {
         // SYNC_TEST + LAYOUT_TEST both pin the window in App.CreateWindow,
         // so the same "skip Maximize" logic in AppFixtureBase applies.
-        env["SYNC_TEST"]   = "1";
+        env["SYNC_TEST"] = "1";
         env["LAYOUT_TEST"] = "1";
     }
 }

--- a/ColorPicker.UITests/PageObjects/ColorSyncTestPageObject.cs
+++ b/ColorPicker.UITests/PageObjects/ColorSyncTestPageObject.cs
@@ -14,15 +14,15 @@ public sealed class ColorSyncTestPageObject
     private readonly WindowsDriver _driver;
     public ColorSyncTestPageObject(WindowsDriver driver) => _driver = driver;
 
-    public AppiumElement InputHex     => Find("InputHex");
-    public AppiumElement InputApply   => Find("InputApply");
-    public AppiumElement InputPreset  => Find("InputPreset");
-    public AppiumElement InputSwatch  => Find("InputSwatch");
+    public AppiumElement InputHex => Find("InputHex");
+    public AppiumElement InputApply => Find("InputApply");
+    public AppiumElement InputPreset => Find("InputPreset");
+    public AppiumElement InputSwatch => Find("InputSwatch");
     public AppiumElement OutputSwatch => Find("OutputSwatch");
-    public AppiumElement OutputHex    => Find("OutputHex");
-    public AppiumElement OutputRgba   => Find("OutputRgba");
+    public AppiumElement OutputHex => Find("OutputHex");
+    public AppiumElement OutputRgba => Find("OutputRgba");
 
-    public string OutputHexText  => SafeText(OutputHex);
+    public string OutputHexText => SafeText(OutputHex);
     public string OutputRgbaText => SafeText(OutputRgba);
 
     public AppiumElement Find(string automationId) =>
@@ -41,7 +41,7 @@ public sealed class ColorSyncTestPageObject
                     return;
             }
             catch (NoSuchElementException) { }
-            catch (WebDriverException)     { }
+            catch (WebDriverException) { }
             Thread.Sleep(200);
         }
         throw new TimeoutException("ColorSyncTestPage did not finish loading within 30s.");

--- a/ColorPicker.UITests/PageObjects/LayoutTestPageObject.cs
+++ b/ColorPicker.UITests/PageObjects/LayoutTestPageObject.cs
@@ -12,13 +12,13 @@ public sealed class LayoutTestPageObject
 
     public LayoutTestPageObject(WindowsDriver driver) => _driver = driver;
 
-    public AppiumElement ScenarioEntry  => Find("ScenarioEntry");
-    public AppiumElement ApplyButton    => Find("ApplyScenario");
-    public AppiumElement CaptureButton  => Find("CaptureCanvas");
-    public AppiumElement CapturePath    => Find("CapturePath");
-    public AppiumElement Host           => Find("ScenarioHost");
-    public AppiumElement Control        => Find("ScenarioControl");
-    public AppiumElement AppliedMarker  => Find("ScenarioApplied");
+    public AppiumElement ScenarioEntry => Find("ScenarioEntry");
+    public AppiumElement ApplyButton => Find("ApplyScenario");
+    public AppiumElement CaptureButton => Find("CaptureCanvas");
+    public AppiumElement CapturePath => Find("CapturePath");
+    public AppiumElement Host => Find("ScenarioHost");
+    public AppiumElement Control => Find("ScenarioControl");
+    public AppiumElement AppliedMarker => Find("ScenarioApplied");
 
     public void WaitUntilLoaded()
     {
@@ -31,7 +31,7 @@ public sealed class LayoutTestPageObject
                 return;
             }
             catch (NoSuchElementException) { Thread.Sleep(250); }
-            catch (WebDriverException)     { Thread.Sleep(250); }
+            catch (WebDriverException) { Thread.Sleep(250); }
         }
         throw new TimeoutException("LayoutTestPage did not display ScenarioEntry within 30s.");
     }
@@ -282,8 +282,8 @@ public readonly record struct ScenarioState(
         var ci = System.Globalization.CultureInfo.InvariantCulture;
         if (!double.TryParse(comma[0], System.Globalization.NumberStyles.Float, ci, out var x)) return false;
         if (!double.TryParse(comma[1], System.Globalization.NumberStyles.Float, ci, out var y)) return false;
-        if (!double.TryParse(sz[0],   System.Globalization.NumberStyles.Float, ci, out var w)) return false;
-        if (!double.TryParse(sz[1],   System.Globalization.NumberStyles.Float, ci, out var h)) return false;
+        if (!double.TryParse(sz[0], System.Globalization.NumberStyles.Float, ci, out var w)) return false;
+        if (!double.TryParse(sz[1], System.Globalization.NumberStyles.Float, ci, out var h)) return false;
         b = new LogicalBounds(x, y, w, h);
         return true;
     }

--- a/ColorPicker.UITests/PageObjects/MainPage.cs
+++ b/ColorPicker.UITests/PageObjects/MainPage.cs
@@ -16,25 +16,25 @@ public sealed class MainPage
     public MainPage(WindowsDriver driver) => _driver = driver;
 
     // Switches
-    public AppiumElement ShowTriangleSwitch         => Find("ShowTriangleSwitch");
-    public AppiumElement ShowAlphaSwitch            => Find("ShowAlphaSwitch");
+    public AppiumElement ShowTriangleSwitch => Find("ShowTriangleSwitch");
+    public AppiumElement ShowAlphaSwitch => Find("ShowAlphaSwitch");
     public AppiumElement ShowLuminositySliderSwitch => Find("ShowLuminositySlider");
-    public AppiumElement ShowLuminosityWheelSwitch  => Find("ShowLuminosityRing");
-    public AppiumElement ShowVerticalSliderSwitch   => Find("ShowVerticalSlider");
-    public AppiumElement RotateTriangleByHueSwitch  => Find("RotateTriangleByHue");
+    public AppiumElement ShowLuminosityWheelSwitch => Find("ShowLuminosityRing");
+    public AppiumElement ShowVerticalSliderSwitch => Find("ShowVerticalSlider");
+    public AppiumElement RotateTriangleByHueSwitch => Find("RotateTriangleByHue");
 
     // Color readouts
-    public string SelectedColorHex  => Find("SelectedColorHex").Text;
+    public string SelectedColorHex => Find("SelectedColorHex").Text;
     public string SelectedColorRgba => Find("SelectedColorRGBA").Text;
     public string SelectedColorHsla => Find("SelectedColorHSLA").Text;
 
     // Custom controls — UIA-opaque (SkiaSharp surface). We expose them via an
     // outer Border host (AutomationId="*Host"). Tests use coordinate-based
     // gestures within the host's bounds.
-    public AppiumElement ColorWheel    => Find("ColorWheel1Host");
+    public AppiumElement ColorWheel => Find("ColorWheel1Host");
     public AppiumElement ColorTriangle => Find("ColorTriangle1Host");
-    public AppiumElement HslSlider    => Find("HSLSliders1Host");
-    public AppiumElement RgbSlider    => Find("RGBSliders1Host");
+    public AppiumElement HslSlider => Find("HSLSliders1Host");
+    public AppiumElement RgbSlider => Find("RGBSliders1Host");
 
     public void WaitUntilLoaded()
     {
@@ -47,7 +47,7 @@ public sealed class MainPage
                 return;
             }
             catch (NoSuchElementException) { Thread.Sleep(250); }
-            catch (WebDriverException)     { Thread.Sleep(250); }
+            catch (WebDriverException) { Thread.Sleep(250); }
         }
         throw new TimeoutException("Sample app did not display ColorWheel within 30s.");
     }
@@ -123,10 +123,10 @@ public sealed class MainPage
     /// <summary>Drag inside the centered square of a control.</summary>
     public void DragInsideSquare(AppiumElement element,
         double fromNormX, double fromNormY,
-        double toNormX,   double toNormY)
+        double toNormX, double toNormY)
     {
         var (x1, y1) = SquareCenteredPoint(element, fromNormX, fromNormY);
-        var (x2, y2) = SquareCenteredPoint(element, toNormX,   toNormY);
+        var (x2, y2) = SquareCenteredPoint(element, toNormX, toNormY);
         var finger = new PointerInputDevice(PointerKind.Touch, "finger");
         var seq = new ActionSequence(finger, 0);
         seq.AddAction(finger.CreatePointerMove(CoordinateOrigin.Viewport, x1, y1, TimeSpan.Zero));
@@ -149,7 +149,7 @@ public sealed class MainPage
     /// <summary>Drag from one normalized point to another inside the control.</summary>
     public void DragInside(AppiumElement element,
         double fromNormX, double fromNormY,
-        double toNormX,   double toNormY)
+        double toNormX, double toNormY)
     {
         var loc  = element.Location;
         var size = element.Size;

--- a/ColorPicker.UITests/Tests/BackgroundTests.cs
+++ b/ColorPicker.UITests/Tests/BackgroundTests.cs
@@ -34,12 +34,12 @@ public class BackgroundTests
     public BackgroundTests(LayoutTestAppFixture fixture) => _fixture = fixture;
 
     [Theory]
-    [InlineData("wheel:400x400:bg=red",        255,   0,   0)]
-    [InlineData("wheel:400x400:bg=blue",         0,   0, 255)]
-    [InlineData("wheel:400x400:bg=yellow",     255, 255,   0)]
-    [InlineData("wheel:400x400:bg=black",        0,   0,   0)]
-    [InlineData("triangle:400x400:bg=red",     255,   0,   0)]
-    [InlineData("triangle:400x400:bg=green",     0, 128,   0)]
+    [InlineData("wheel:400x400:bg=red", 255, 0, 0)]
+    [InlineData("wheel:400x400:bg=blue", 0, 0, 255)]
+    [InlineData("wheel:400x400:bg=yellow", 255, 255, 0)]
+    [InlineData("wheel:400x400:bg=black", 0, 0, 0)]
+    [InlineData("triangle:400x400:bg=red", 255, 0, 0)]
+    [InlineData("triangle:400x400:bg=green", 0, 128, 0)]
     public void Host_Background_Shows_Through_Canvas_Corners(
         string scenario, int r, int g, int b)
     {

--- a/ColorPicker.UITests/Tests/ColorSyncExpectedPickerOffsets.cs
+++ b/ColorPicker.UITests/Tests/ColorSyncExpectedPickerOffsets.cs
@@ -17,22 +17,22 @@ internal static class ColorSyncExpectedPickerOffsets
 {
     public static readonly IReadOnlyDictionary<(string Cell, string Hex), (double Rx, double Ry)> Offsets =
         new Dictionary<(string, string), (double, double)>
-    {
-        [("C_WheelDefault", "#FF0000FF")] = (0.2500, 0.5550), // red           luma=0
-        [("C_TriRotate",    "#FF0000FF")] = (0.1189, 0.5211), // red           luma=0
-        [("C_WheelDefault", "#00FF00FF")] = (0.6311, 0.7906), // green         luma=2
-        [("C_TriRotate",    "#00FF00FF")] = (0.6639, 0.8947), // green         luma=0
-        [("C_WheelDefault", "#0000FFFF")] = (0.5902, 0.2513), // blue          luma=1
-        [("C_TriRotate",    "#0000FFFF")] = (0.6803, 0.1105), // blue          luma=0
-        [("C_WheelDefault", "#FFFF00FF")] = (0.3648, 0.7906), // yellow        luma=3
-        [("C_TriRotate",    "#FFFF00FF")] = (0.3320, 0.8947), // yellow        luma=0
-        [("C_WheelDefault", "#00FFFFFF")] = (0.7459, 0.5550), // cyan          luma=3
-        [("C_TriRotate",    "#00FFFFFF")] = (0.8279, 0.5211), // cyan          luma=0
-        [("C_WheelDefault", "#FF00FFFF")] = (0.3320, 0.2356), // magenta       luma=0
-        [("C_TriRotate",    "#FF00FFFF")] = (0.3074, 0.1105), // magenta       luma=0
-        [("C_WheelDefault", "#FFA500FF")] = (0.2910, 0.6911), // orange        luma=0
-        [("C_TriRotate",    "#FFA500FF")] = (0.2213, 0.8053), // orange        luma=0
-        [("C_WheelDefault", "#FF000080")] = (0.2500, 0.5550), // red-alpha-50  luma=0
-        [("C_TriRotate",    "#FF000080")] = (0.1189, 0.5211), // red-alpha-50  luma=0
-    };
+        {
+            [("C_WheelDefault", "#FF0000FF")] = (0.2500, 0.5550), // red           luma=0
+            [("C_TriRotate",    "#FF0000FF")] = (0.1189, 0.5211), // red           luma=0
+            [("C_WheelDefault", "#00FF00FF")] = (0.6311, 0.7906), // green         luma=2
+            [("C_TriRotate",    "#00FF00FF")] = (0.6639, 0.8947), // green         luma=0
+            [("C_WheelDefault", "#0000FFFF")] = (0.5902, 0.2513), // blue          luma=1
+            [("C_TriRotate",    "#0000FFFF")] = (0.6803, 0.1105), // blue          luma=0
+            [("C_WheelDefault", "#FFFF00FF")] = (0.3648, 0.7906), // yellow        luma=3
+            [("C_TriRotate",    "#FFFF00FF")] = (0.3320, 0.8947), // yellow        luma=0
+            [("C_WheelDefault", "#00FFFFFF")] = (0.7459, 0.5550), // cyan          luma=3
+            [("C_TriRotate",    "#00FFFFFF")] = (0.8279, 0.5211), // cyan          luma=0
+            [("C_WheelDefault", "#FF00FFFF")] = (0.3320, 0.2356), // magenta       luma=0
+            [("C_TriRotate",    "#FF00FFFF")] = (0.3074, 0.1105), // magenta       luma=0
+            [("C_WheelDefault", "#FFA500FF")] = (0.2910, 0.6911), // orange        luma=0
+            [("C_TriRotate",    "#FFA500FF")] = (0.2213, 0.8053), // orange        luma=0
+            [("C_WheelDefault", "#FF000080")] = (0.2500, 0.5550), // red-alpha-50  luma=0
+            [("C_TriRotate",    "#FF000080")] = (0.1189, 0.5211), // red-alpha-50  luma=0
+        };
 }

--- a/ColorPicker.UITests/Tests/ColorSyncTests.cs
+++ b/ColorPicker.UITests/Tests/ColorSyncTests.cs
@@ -80,7 +80,7 @@ public sealed class ColorSyncTests : IClassFixture<SyncTestAppFixture>
         if (s < 0.20) return; // see XML doc
 
         AssertPickerAt(img, "C_WheelDefault", hex);
-        AssertPickerAt(img, "C_TriRotate",    hex);
+        AssertPickerAt(img, "C_TriRotate", hex);
     }
 
     /// <summary>
@@ -154,9 +154,9 @@ public sealed class ColorSyncTests : IClassFixture<SyncTestAppFixture>
         {
             double d = max - min;
             s = l > 0.5 ? d / (2.0 - max - min) : d / (max + min);
-            if      (max == dr) h = (dg - db) / d + (dg < db ? 6 : 0);
+            if (max == dr) h = (dg - db) / d + (dg < db ? 6 : 0);
             else if (max == dg) h = (db - dr) / d + 2;
-            else                h = (dr - dg) / d + 4;
+            else h = (dr - dg) / d + 4;
             h /= 6.0;
         }
         return (h, s, l);

--- a/ColorPicker.UITests/Tests/ColorSyncUiDrivenTests.cs
+++ b/ColorPicker.UITests/Tests/ColorSyncUiDrivenTests.cs
@@ -151,9 +151,9 @@ public sealed class ColorSyncUiDrivenTests : IClassFixture<SyncTestAppFixture>
         {
             double d = max - min;
             s = l > 0.5 ? d / (2.0 - max - min) : d / (max + min);
-            if      (max == dr) h = (dg - db) / d + (dg < db ? 6 : 0);
+            if (max == dr) h = (dg - db) / d + (dg < db ? 6 : 0);
             else if (max == dg) h = (db - dr) / d + 2;
-            else                h = (dr - dg) / d + 4;
+            else h = (dr - dg) / d + 4;
             h /= 6.0;
         }
         return (h, s, l);

--- a/ColorPicker.UITests/Tests/LayoutSmokeTests.cs
+++ b/ColorPicker.UITests/Tests/LayoutSmokeTests.cs
@@ -25,8 +25,8 @@ public class LayoutSmokeTests : IClassFixture<AppiumServerFixture>, IClassFixtur
         var data = new TheoryData<string>();
         var sizes = new[] { "100x100", "800x800", "300x600", "600x300" };
         foreach (var ctrl in new[] { "wheel", "triangle", "hsl", "rgb" })
-        foreach (var sz in sizes)
-            data.Add($"{ctrl}:{sz}");
+            foreach (var sz in sizes)
+                data.Add($"{ctrl}:{sz}");
         return data;
     }
 

--- a/ColorPicker.UITests/Tests/PixelDiffTests.cs
+++ b/ColorPicker.UITests/Tests/PixelDiffTests.cs
@@ -35,12 +35,12 @@ public class PixelDiffTests
     // perPixelTol: sum-of-RGB diff per pixel that counts as a "match".
     // maxBadFrac:  fraction of pixels allowed to exceed perPixelTol.
     [Theory]
-    [InlineData("wheel-400-default",         "wheel:400x400",                  30, 0.015)]
-    [InlineData("wheel-400-alpha",           "wheel:400x400:alpha",            30, 0.015)]
-    [InlineData("wheel-400-vertical-alpha",  "wheel:400x400:alpha,vertical",   30, 0.015)]
-    [InlineData("triangle-400-default",      "triangle:400x400",               30, 0.015)]
-    [InlineData("wheel-400-bg-red",          "wheel:400x400:bg=red",           30, 0.015)]
-    [InlineData("wheel-400-nolumwheel",      "wheel:400x400:nolumwheel",       30, 0.015)]
+    [InlineData("wheel-400-default", "wheel:400x400", 30, 0.015)]
+    [InlineData("wheel-400-alpha", "wheel:400x400:alpha", 30, 0.015)]
+    [InlineData("wheel-400-vertical-alpha", "wheel:400x400:alpha,vertical", 30, 0.015)]
+    [InlineData("triangle-400-default", "triangle:400x400", 30, 0.015)]
+    [InlineData("wheel-400-bg-red", "wheel:400x400:bg=red", 30, 0.015)]
+    [InlineData("wheel-400-nolumwheel", "wheel:400x400:nolumwheel", 30, 0.015)]
     public void Matches_Reference(string id, string scenario, int perPixelTol, double maxBadFrac)
     {
         var page = _fixture.Page;

--- a/ColorPicker.UITests/Tests/SettingsToggleTests.cs
+++ b/ColorPicker.UITests/Tests/SettingsToggleTests.cs
@@ -91,14 +91,14 @@ public sealed class SettingsToggleTests : IClassFixture<AppFixture>
         int xMax = Math.Min(x + w, Math.Min(a.Width,  b.Width));
         int yMax = Math.Min(y + h, Math.Min(a.Height, b.Height));
         for (int j = Math.Max(0, y); j < yMax; j++)
-        for (int i = Math.Max(0, x); i < xMax; i++)
-        {
-            var pa = a[i, j]; var pb = b[i, j];
-            if (Math.Abs(pa.R - pb.R) > channelTol ||
-                Math.Abs(pa.G - pb.G) > channelTol ||
-                Math.Abs(pa.B - pb.B) > channelTol)
-                diff++;
-        }
+            for (int i = Math.Max(0, x); i < xMax; i++)
+            {
+                var pa = a[i, j]; var pb = b[i, j];
+                if (Math.Abs(pa.R - pb.R) > channelTol ||
+                    Math.Abs(pa.G - pb.G) > channelTol ||
+                    Math.Abs(pa.B - pb.B) > channelTol)
+                    diff++;
+            }
         return diff;
     }
 

--- a/ColorPicker.UITests/Tests/SmokeTests.cs
+++ b/ColorPicker.UITests/Tests/SmokeTests.cs
@@ -12,7 +12,7 @@ public sealed class SmokeTests : IClassFixture<AppFixture>
     public void App_Launches_And_ShowsColorWheel()
     {
         var size = _fx.Page.ColorWheel.Size;
-        Assert.True(size.Width  > 50, $"ColorWheel width too small: {size.Width}");
+        Assert.True(size.Width > 50, $"ColorWheel width too small: {size.Width}");
         Assert.True(size.Height > 50, $"ColorWheel height too small: {size.Height}");
     }
 

--- a/ColorPicker.UITests/Tests/VisualProbe.cs
+++ b/ColorPicker.UITests/Tests/VisualProbe.cs
@@ -32,7 +32,8 @@ public class VisualProbe
             // we still emit duplicates with -dup suffix so the manifest is complete.
         }
         var list = new List<(string id, string spec)>();
-        void Emit(string id, string spec) {
+        void Emit(string id, string spec)
+        {
             // ensure unique id by suffixing
             string useId = id; int i = 1;
             while (list.Any(t => t.id == useId)) useId = id + "-" + (++i);
@@ -41,8 +42,8 @@ public class VisualProbe
 
         // Tier 1 — LayoutSmoke
         foreach (var ctrl in new[] { "wheel", "triangle", "hsl", "rgb" })
-        foreach (var sz   in new[] { "100x100", "800x800", "300x600", "600x300" })
-            Emit($"smoke-{ctrl}-{sz}", $"{ctrl}:{sz}");
+            foreach (var sz in new[] { "100x100", "800x800", "300x600", "600x300" })
+                Emit($"smoke-{ctrl}-{sz}", $"{ctrl}:{sz}");
 
         // Tier 2 — feature matrix
         for (int mask = 0; mask < 16; mask++)
@@ -53,7 +54,7 @@ public class VisualProbe
             if ((mask & 4) == 0) opts.Add("nolumwheel");
             if ((mask & 8) != 0) opts.Add("vertical");
             var spec = opts.Count == 0 ? "wheel:400x400" : "wheel:400x400:" + string.Join(",", opts);
-            Emit($"feat-{mask:00}-{string.Join("_", opts)}".TrimEnd('-','_'), spec);
+            Emit($"feat-{mask:00}-{string.Join("_", opts)}".TrimEnd('-', '_'), spec);
         }
 
         // Tier 4 — container sizing
@@ -62,38 +63,38 @@ public class VisualProbe
             "wheel:fillx400","wheel:fillxfill","wheel:fillxauto",
             "wheel:autox400","wheel:autoxfill","wheel:autoxauto",
             "triangle:fillxfill","rgb:fillxfill","hsl:fillxfill" })
-            Emit("sizing-" + s.Replace(":","-").Replace(",","_"), s);
+            Emit("sizing-" + s.Replace(":", "-").Replace(",", "_"), s);
 
         // Padding
-        foreach (var s in new[] {"wheel:300x300","wheel:600x600","triangle:300x300"})
-            Emit("padding-" + s.Replace(":","-"), s);
+        foreach (var s in new[] { "wheel:300x300", "wheel:600x600", "triangle:300x300" })
+            Emit("padding-" + s.Replace(":", "-"), s);
 
         // Triangle ring modes (rotate-with-hue vs. fixed-triangle rotating ring)
         foreach (var sz in new[] { "400x400", "300x600", "600x300" })
         {
-            Emit($"triangle-rotate-{sz}",   $"triangle:{sz}");
+            Emit($"triangle-rotate-{sz}", $"triangle:{sz}");
             Emit($"triangle-norotate-{sz}", $"triangle:{sz}:norotate");
         }
 
         // Slider orientation + alpha visibility
         foreach (var ctrl in new[] { "hsl", "rgb" })
-        foreach (var sz   in new[] { "400x400", "300x600", "600x300" })
-        {
-            Emit($"slider-{ctrl}-vertical-{sz}", $"{ctrl}:{sz}:vertical");
-            Emit($"slider-{ctrl}-noalpha-{sz}",  $"{ctrl}:{sz}:noalpha");
-        }
+            foreach (var sz in new[] { "400x400", "300x600", "600x300" })
+            {
+                Emit($"slider-{ctrl}-vertical-{sz}", $"{ctrl}:{sz}:vertical");
+                Emit($"slider-{ctrl}-noalpha-{sz}", $"{ctrl}:{sz}:noalpha");
+            }
 
         // Tier — fixed IndicatorRadiusScale on standalone sliders. Without prs the
         // slider stack fills the whole cell; with prs > 0 the orthogonal axis
         // becomes fixed (thickness = count * 2.2 * prs * length) and only the
         // length axis still fills.
         foreach (var ctrl in new[] { "hsl", "rgb" })
-        foreach (var sz   in new[] { "400x400", "600x300", "300x600" })
-        foreach (var scale in new[] { "0.04", "0.08" })
-        {
-            Emit($"prs-{ctrl}-{sz}-prs{scale.Replace(".","")}",            $"{ctrl}:{sz}:prs={scale}");
-            Emit($"prs-{ctrl}-{sz}-vertical-prs{scale.Replace(".","")}",   $"{ctrl}:{sz}:vertical,prs={scale}");
-        }
+            foreach (var sz in new[] { "400x400", "600x300", "300x600" })
+                foreach (var scale in new[] { "0.04", "0.08" })
+                {
+                    Emit($"prs-{ctrl}-{sz}-prs{scale.Replace(".", "")}", $"{ctrl}:{sz}:prs={scale}");
+                    Emit($"prs-{ctrl}-{sz}-vertical-prs{scale.Replace(".", "")}", $"{ctrl}:{sz}:vertical,prs={scale}");
+                }
 
         // Control-internal background (wbg=) — distinct from host bg=
         foreach (var s in new[] {
@@ -101,14 +102,14 @@ public class VisualProbe
             "wheel:400x400:wbg=yellow",
             "triangle:400x400:wbg=red",
             "triangle:400x400:wbg=blue" })
-            Emit("wbg-" + s.Replace(":","-").Replace("=","-").Replace("#",""), s);
+            Emit("wbg-" + s.Replace(":", "-").Replace("=", "-").Replace("#", ""), s);
 
         // Background
         foreach (var s in new[] {
             "wheel:400x400:bg=red","wheel:400x400:bg=blue","wheel:400x400:bg=yellow",
             "wheel:400x400:bg=black","triangle:400x400:bg=red","triangle:400x400:bg=green",
             "wheel:400x400:bg=#FF8000" })
-            Emit("bg-" + s.Replace(":","-").Replace("=","-").Replace("#","").Replace(",","_"), s);
+            Emit("bg-" + s.Replace(":", "-").Replace("=", "-").Replace("#", "").Replace(",", "_"), s);
 
         // Window events used "wheel:fillxfill" already.
 

--- a/ColorPicker.UITests/Tests/WindowEventTests.cs
+++ b/ColorPicker.UITests/Tests/WindowEventTests.cs
@@ -42,7 +42,7 @@ public class WindowEventTests
             Math.Abs(s.HostBounds.W - s.ViewportBounds.W) <= 2 &&
             s.ViewportBounds.W > small.ViewportBounds.W);
 
-        Assert.True(big.HostBounds.W   > small.HostBounds.W,
+        Assert.True(big.HostBounds.W > small.HostBounds.W,
             $"Host did not grow: small={small.HostBounds.W}, big={big.HostBounds.W}");
         Assert.True(big.ControlBounds.W > 0 && big.ControlBounds.W <= big.HostBounds.W + 1,
             $"Control did not adapt to new host size: {big.ControlBounds.W} / {big.HostBounds.W}");

--- a/ColorPicker/BaseClasses/ColorPickerBase.cs
+++ b/ColorPicker/BaseClasses/ColorPickerBase.cs
@@ -14,54 +14,54 @@ public abstract class ColorPickerBase : Layout, IColorPicker, IRegisterable
     //  Bindable objects
     //
     public static readonly BindableProperty SelectedColorProperty
-                         = BindableProperty.Create( nameof(SelectedColor),
+                         = BindableProperty.Create(nameof(SelectedColor),
                                                     typeof(Color),
                                                     typeof(ColorPickerBase),
                                                     Color.FromHsla(0, 0, 0.5),
-                                                    propertyChanged: HandleSelectedColor );
+                                                    propertyChanged: HandleSelectedColor);
 
     public static readonly BindableProperty AttachedColorPickerProperty
-                         = BindableProperty.Create( nameof(AttachedColorPicker),
+                         = BindableProperty.Create(nameof(AttachedColorPicker),
                                                     typeof(IColorPicker),
                                                     typeof(ColorPickerBase),
                                                     null,
-                                                    propertyChanged: HandleConnectedColorPicker );
+                                                    propertyChanged: HandleConnectedColorPicker);
 
     //  Backing store
     //
-    public Color SelectedColor 
-    { 
-        get => (Color)GetValue( SelectedColorProperty ); 
-        set => SetValue( SelectedColorProperty, value ); 
+    public Color SelectedColor
+    {
+        get => (Color)GetValue(SelectedColorProperty);
+        set => SetValue(SelectedColorProperty, value);
     }
 
     public IColorPicker AttachedColorPicker
     {
-        get => (IColorPicker)GetValue( AttachedColorPickerProperty );
-        set => SetValue( AttachedColorPickerProperty, value );
+        get => (IColorPicker)GetValue(AttachedColorPickerProperty);
+        set => SetValue(AttachedColorPickerProperty, value);
     }
 
     //  ColorPicker Subclass must implement to intercept SelectedColor change
     //
-    protected abstract void OnSelectedColorChanging( Color color );
+    protected abstract void OnSelectedColorChanging(Color color);
 
     //  Required for .NET 8 MAUI Layout - use a simple layout manager
     //  that properly delegates measurement and arrangement to children
     //
     protected override ILayoutManager CreateLayoutManager()
-        => new ColorPickerLayoutManager( this );
+        => new ColorPickerLayoutManager(this);
 
     /// <summary>
     /// Called by the layout manager to arrange children within the layout.
     /// The native LayoutPanel uses this to position native child views.
     /// Override in subclasses for custom child positioning.
     /// </summary>
-    protected virtual Size ArrangeLayoutChildren( Rect bounds )
+    protected virtual Size ArrangeLayoutChildren(Rect bounds)
     {
         // Default: arrange all children to fill bounds
-        foreach ( var child in Children )
+        foreach (var child in Children)
         {
-            ( (IView)child ).Arrange( bounds );
+            ((IView)child).Arrange(bounds);
         }
         return bounds.Size;
     }
@@ -71,75 +71,75 @@ public abstract class ColorPickerBase : Layout, IColorPicker, IRegisterable
         readonly ColorPickerBase _layout;
         bool _measuring;
 
-        public ColorPickerLayoutManager( ColorPickerBase layout ) => _layout = layout;
+        public ColorPickerLayoutManager(ColorPickerBase layout) => _layout = layout;
 
-        public Size Measure( double widthConstraint, double heightConstraint )
+        public Size Measure(double widthConstraint, double heightConstraint)
         {
             // Apply the layout's WidthRequest/HeightRequest before measuring children.
             // Without this, children get the raw parent constraints (e.g. 1192??)
             // and SkiaSharp renders at that size, causing clipping.
-            if ( _layout.WidthRequest >= 0 )
-                widthConstraint = Math.Min( widthConstraint, _layout.WidthRequest );
-            if ( _layout.HeightRequest >= 0 )
-                heightConstraint = Math.Min( heightConstraint, _layout.HeightRequest );
+            if (_layout.WidthRequest >= 0)
+                widthConstraint = Math.Min(widthConstraint, _layout.WidthRequest);
+            if (_layout.HeightRequest >= 0)
+                heightConstraint = Math.Min(heightConstraint, _layout.HeightRequest);
 
             // Measure all children with constrained values
-            foreach ( var child in _layout.Children )
+            foreach (var child in _layout.Children)
             {
-                ( (IView)child ).Measure( widthConstraint, heightConstraint );
+                ((IView)child).Measure(widthConstraint, heightConstraint);
             }
 
             // Return the same size as MeasureOverride to keep native panel
             // and MAUI layout in sync.
-            if ( !_measuring )
+            if (!_measuring)
             {
                 _measuring = true;
-                var result = _layout.MeasureOverride( widthConstraint, heightConstraint );
+                var result = _layout.MeasureOverride(widthConstraint, heightConstraint);
                 _measuring = false;
                 return result;
             }
 
             // Fallback for recursive calls
-            var width = double.IsInfinity( widthConstraint ) ? 0 : widthConstraint;
-            var height = double.IsInfinity( heightConstraint ) ? 0 : heightConstraint;
-            return new Size( width, height );
+            var width = double.IsInfinity(widthConstraint) ? 0 : widthConstraint;
+            var height = double.IsInfinity(heightConstraint) ? 0 : heightConstraint;
+            return new Size(width, height);
         }
 
-        public Size ArrangeChildren( Rect bounds )
+        public Size ArrangeChildren(Rect bounds)
         {
-            return _layout.ArrangeLayoutChildren( bounds );
+            return _layout.ArrangeLayoutChildren(bounds);
         }
     }
 
     //  Handles SelectedColor change
     //
-    static void HandleSelectedColor( BindableObject bindable, object oldValue, object newValue )
+    static void HandleSelectedColor(BindableObject bindable, object oldValue, object newValue)
     {
-        if ( bindable is not ColorPickerBase viewBase )
+        if (bindable is not ColorPickerBase viewBase)
             return;
 
         if (oldValue != newValue)
         {
             //  Calls subclass implementation
-            viewBase.OnSelectedColorChanging( (Color)newValue );
+            viewBase.OnSelectedColorChanging((Color)newValue);
 
-            if ( viewBase.AttachedColorPicker is not null )
+            if (viewBase.AttachedColorPicker is not null)
             {
                 viewBase.AttachedColorPicker.SelectedColor = (Color)newValue;
             }
 
-            viewBase.RaiseSelectedColorChanged( (Color)oldValue, (Color)newValue );
+            viewBase.RaiseSelectedColorChanged((Color)oldValue, (Color)newValue);
         }
     }
 
     //  Connects to and/or disconnects from bound ColorPicker 
     //
-    static void HandleConnectedColorPicker( BindableObject bindable, object oldValue, object newValue )
+    static void HandleConnectedColorPicker(BindableObject bindable, object oldValue, object newValue)
     {
         if (bindable is not ColorPickerBase viewBase)
             return;
 
-        if ( oldValue is not null )
+        if (oldValue is not null)
         {
             ((IColorPicker)oldValue).PropertyChanged -= viewBase.BoundColorPicker_PropertyChanged;
         }
@@ -147,16 +147,16 @@ public abstract class ColorPickerBase : Layout, IColorPicker, IRegisterable
         if (newValue is not null)
         {
             ((IColorPicker)newValue).PropertyChanged += viewBase.BoundColorPicker_PropertyChanged;
-            ((IColorPicker)newValue).SelectedColor    = viewBase.SelectedColor;
+            ((IColorPicker)newValue).SelectedColor = viewBase.SelectedColor;
         }
     }
 
     /// <summary>
     /// Property changed event handler
     /// </summary>
-    void BoundColorPicker_PropertyChanged( object sender, System.ComponentModel.PropertyChangedEventArgs e )
+    void BoundColorPicker_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
-        if (e.PropertyName == nameof( SelectedColor ))
+        if (e.PropertyName == nameof(SelectedColor))
         {
             SelectedColor = ((IColorPicker)sender).SelectedColor;
         }
@@ -167,6 +167,6 @@ public abstract class ColorPickerBase : Layout, IColorPicker, IRegisterable
     /// </summary>
     public event EventHandler<ColorChangedEventArgs> SelectedColorChanged;
 
-    protected virtual void RaiseSelectedColorChanged( Color oldColor, Color newColor )
-                        => SelectedColorChanged?.Invoke( this, new ColorChangedEventArgs( oldColor, newColor ) );
+    protected virtual void RaiseSelectedColorChanged(Color oldColor, Color newColor)
+                        => SelectedColorChanged?.Invoke(this, new ColorChangedEventArgs(oldColor, newColor));
 }

--- a/ColorPicker/BaseClasses/SkiaPickerBase.cs
+++ b/ColorPicker/BaseClasses/SkiaPickerBase.cs
@@ -14,93 +14,93 @@ public abstract class SkiaPickerBase : ColorPickerBase
     protected readonly SKCanvasView     CanvasView;
 
     public static readonly BindableProperty IndicatorRadiusScaleProperty
-                         = BindableProperty.Create( nameof(IndicatorRadiusScale),
+                         = BindableProperty.Create(nameof(IndicatorRadiusScale),
                                                     typeof(float),
                                                     typeof(SkiaPickerBase),
                                                     0.05F,
-                                                    propertyChanged: HandlePickerRadiusScaleSet );
+                                                    propertyChanged: HandlePickerRadiusScaleSet);
     public float IndicatorRadiusScale
     {
-        get => (float)GetValue( IndicatorRadiusScaleProperty );
-        set => SetValue( IndicatorRadiusScaleProperty, value );
+        get => (float)GetValue(IndicatorRadiusScaleProperty);
+        set => SetValue(IndicatorRadiusScaleProperty, value);
     }
 
-    static void HandlePickerRadiusScaleSet( BindableObject bindable, object oldValue, object newValue )
-            => ( (SkiaPickerBase)bindable ).InvalidateSurface();
+    static void HandlePickerRadiusScaleSet(BindableObject bindable, object oldValue, object newValue)
+            => ((SkiaPickerBase)bindable).InvalidateSurface();
 
     /// <summary>
     /// Constructor
     /// </summary>
     public SkiaPickerBase()
     {
-        HorizontalOptions           =   LayoutOptions.Center;
-        VerticalOptions             =   LayoutOptions.Center;
+        HorizontalOptions = LayoutOptions.Center;
+        VerticalOptions = LayoutOptions.Center;
 
         var touchBehavior           =   new TouchBehavior();
 
 #if WINDOWS
-        var touchImpl               =   new WindowsTouchActionBehavior( touchBehavior );
+        var touchImpl               =   new WindowsTouchActionBehavior(touchBehavior);
 #elif ANDROID
-        var touchImpl               =   new AndroidTouchActionBehavior( touchBehavior );
+        var touchImpl               =   new AndroidTouchActionBehavior(touchBehavior);
 #else
-        throw new NotImplementedException( "Specified platform not yet implemented" );
+        throw new NotImplementedException("Specified platform not yet implemented");
 #endif
 
         var view                    =   new SKCanvasView();
-        view.PaintSurface          +=   OnPaintSurface;
-        view.Loaded                +=   OnCanvasViewLoaded;
-        CanvasView                =   view;
+        view.PaintSurface += OnPaintSurface;
+        view.Loaded += OnCanvasViewLoaded;
+        CanvasView = view;
 
-        touchBehavior.Capture       =   true;
-        touchBehavior.TouchAction  +=   OnTouchAction;
+        touchBehavior.Capture = true;
+        touchBehavior.TouchAction += OnTouchAction;
 
-        Behaviors.Add( touchImpl );
-        Children.Add( CanvasView );
+        Behaviors.Add(touchImpl);
+        Children.Add(CanvasView);
     }
 
-    public abstract     float       GetIndicatorRadiusPixels();
-    public abstract     float       GetIndicatorRadiusPixels( SKSize canvasSize );
+    public abstract float GetIndicatorRadiusPixels();
+    public abstract float GetIndicatorRadiusPixels(SKSize canvasSize);
 
-    protected abstract  SizeRequest GetMeasure( double widthConstraint, double heightConstraint );
-    protected abstract  float       GetSize();
-    protected abstract  float       GetSize( SKSize canvasSize );
-    protected abstract  void        OnPaintSurface( SKCanvas canvas, int width, int height );
-    protected abstract  void        OnTouchActionPressed( TouchActionEventArgs args );
-    protected abstract  void        OnTouchActionMoved( TouchActionEventArgs args );
-    protected abstract  void        OnTouchActionReleased( TouchActionEventArgs args );
-    protected abstract  void        OnTouchActionCancelled( TouchActionEventArgs args );
+    protected abstract SizeRequest GetMeasure(double widthConstraint, double heightConstraint);
+    protected abstract float GetSize();
+    protected abstract float GetSize(SKSize canvasSize);
+    protected abstract void OnPaintSurface(SKCanvas canvas, int width, int height);
+    protected abstract void OnTouchActionPressed(TouchActionEventArgs args);
+    protected abstract void OnTouchActionMoved(TouchActionEventArgs args);
+    protected abstract void OnTouchActionReleased(TouchActionEventArgs args);
+    protected abstract void OnTouchActionCancelled(TouchActionEventArgs args);
 
-    protected override Size MeasureOverride( double widthConstraint, double heightConstraint )
+    protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
     {
         // Apply WidthRequest/HeightRequest as constraints
-        if ( WidthRequest >= 0 )
-            widthConstraint = Math.Min( widthConstraint, WidthRequest );
-        if ( HeightRequest >= 0 )
-            heightConstraint = Math.Min( heightConstraint, HeightRequest );
+        if (WidthRequest >= 0)
+            widthConstraint = Math.Min(widthConstraint, WidthRequest);
+        if (HeightRequest >= 0)
+            heightConstraint = Math.Min(heightConstraint, HeightRequest);
 
-        var sizeRequest = GetMeasure( widthConstraint, heightConstraint );
+        var sizeRequest = GetMeasure(widthConstraint, heightConstraint);
         var size = sizeRequest.Request;
 
         // Measure the child SKCanvasView so MAUI knows it needs rendering
-        ( (IView)CanvasView ).Measure( size.Width, size.Height );
+        ((IView)CanvasView).Measure(size.Width, size.Height);
 
         return size;
     }
 
-    protected override Size ArrangeOverride( Rect bounds )
+    protected override Size ArrangeOverride(Rect bounds)
     {
         // Call base which sets Frame, calls PlatformArrange on the native container,
         // and calls LayoutManager.ArrangeChildren to position native child views.
-        var result = base.ArrangeOverride( bounds );
+        var result = base.ArrangeOverride(bounds);
 
         // MAUI's base ArrangeOverride passes the *stale* Frame size to LayoutManager.ArrangeChildren
         // instead of our fresh `bounds`, so the SKCanvasView child can end up arranged at the
         // previous size. Re-arrange explicitly using the freshly-updated Frame size (which is
         // the actual on-screen size of this control, after centering/alignment is applied).
         var size = Frame.Size;
-        if ( size.Width > 0 && size.Height > 0 )
+        if (size.Width > 0 && size.Height > 0)
         {
-            ( (IView)CanvasView ).Arrange( new Rect( 0, 0, size.Width, size.Height ) );
+            ((IView)CanvasView).Arrange(new Rect(0, 0, size.Width, size.Height));
         }
 
         InvalidateSurface();
@@ -108,22 +108,22 @@ public abstract class SkiaPickerBase : ColorPickerBase
         return result;
     }
 
-    protected SKPoint ConvertToPixel( Point pt )
+    protected SKPoint ConvertToPixel(Point pt)
     {
         var canvasSize = GetCanvasSize();
-        return new SKPoint( (float)( canvasSize.Width * pt.X / CanvasView.Width ),
-                           (float)( canvasSize.Height * pt.Y / CanvasView.Height ) );
+        return new SKPoint((float)(canvasSize.Width * pt.X / CanvasView.Width),
+                           (float)(canvasSize.Height * pt.Y / CanvasView.Height));
     }
 
-    protected SKSize GetCanvasSize()    => CanvasView.CanvasSize;
-    protected void InvalidateSurface()  => CanvasView.InvalidateSurface();
+    protected SKSize GetCanvasSize() => CanvasView.CanvasSize;
+    protected void InvalidateSurface() => CanvasView.InvalidateSurface();
 
-    void OnCanvasViewLoaded( object sender, EventArgs e )
+    void OnCanvasViewLoaded(object sender, EventArgs e)
     {
         InvalidateSurface();
     }
 
-    protected void PaintIndicator( SKCanvas canvas, SKPoint point )
+    protected void PaintIndicator(SKCanvas canvas, SKPoint point)
     {
         var paint = new SKPaint
         {
@@ -131,36 +131,36 @@ public abstract class SkiaPickerBase : ColorPickerBase
             Style = SKPaintStyle.Stroke
         };
 
-        paint.Color         = Colors.White.ToSKColor();
-        paint.StrokeWidth   = 2;
-        canvas.DrawCircle( point, GetIndicatorRadiusPixels() - 2, paint );
+        paint.Color = Colors.White.ToSKColor();
+        paint.StrokeWidth = 2;
+        canvas.DrawCircle(point, GetIndicatorRadiusPixels() - 2, paint);
 
-        paint.Color         = Colors.Black.ToSKColor();
-        paint.StrokeWidth   = 1;
-        canvas.DrawCircle( point, GetIndicatorRadiusPixels() - 4, paint );
-        canvas.DrawCircle( point, GetIndicatorRadiusPixels(), paint );
+        paint.Color = Colors.Black.ToSKColor();
+        paint.StrokeWidth = 1;
+        canvas.DrawCircle(point, GetIndicatorRadiusPixels() - 4, paint);
+        canvas.DrawCircle(point, GetIndicatorRadiusPixels(), paint);
     }
 
-    void OnPaintSurface( object sender, SKPaintSurfaceEventArgs e )
+    void OnPaintSurface(object sender, SKPaintSurfaceEventArgs e)
     {
-        OnPaintSurface( e.Surface.Canvas, e.Info.Width, e.Info.Height );
+        OnPaintSurface(e.Surface.Canvas, e.Info.Width, e.Info.Height);
     }
 
-    void OnTouchAction( object sender, TouchActionEventArgs e )
+    void OnTouchAction(object sender, TouchActionEventArgs e)
     {
-        switch ( e.Type )
+        switch (e.Type)
         {
             case TouchActionType.Pressed:
-                OnTouchActionPressed( e );
+                OnTouchActionPressed(e);
                 break;
             case TouchActionType.Moved:
-                OnTouchActionMoved( e );
+                OnTouchActionMoved(e);
                 break;
             case TouchActionType.Released:
-                OnTouchActionReleased( e );
+                OnTouchActionReleased(e);
                 break;
             case TouchActionType.Cancelled:
-                OnTouchActionCancelled( e );
+                OnTouchActionCancelled(e);
                 break;
         }
     }

--- a/ColorPicker/BaseClasses/SliderBase.cs
+++ b/ColorPicker/BaseClasses/SliderBase.cs
@@ -2,9 +2,9 @@
 
 public abstract class SliderBase
 {
-    public bool             PaintChessPattern   { get; set; }
+    public bool PaintChessPattern { get; set; }
 
-    public abstract float   NewValue( Color color );
-    public abstract Color   GetNewColor( float newValue, Color oldColor );
-    public abstract SKPaint GetPaint( Color color, SKPoint startPoint, SKPoint endPoint );
+    public abstract float NewValue(Color color);
+    public abstract Color GetNewColor(float newValue, Color oldColor);
+    public abstract SKPaint GetPaint(Color color, SKPoint startPoint, SKPoint endPoint);
 }

--- a/ColorPicker/BaseClasses/SliderStack.cs
+++ b/ColorPicker/BaseClasses/SliderStack.cs
@@ -16,42 +16,42 @@ public abstract class SliderStack : SkiaPickerBase
         UpdateSliders();
     }
 
-    public static readonly BindableProperty VerticalProperty 
-                         = BindableProperty.Create( nameof(Vertical),
+    public static readonly BindableProperty VerticalProperty
+                         = BindableProperty.Create(nameof(Vertical),
                                                     typeof(bool),
                                                     typeof(SliderStack),
                                                     false,
-                                                    propertyChanged: HandleVerticalSet );
+                                                    propertyChanged: HandleVerticalSet);
     public bool Vertical
     {
-        get => (bool)GetValue( VerticalProperty );
-        set => SetValue( VerticalProperty, value );
+        get => (bool)GetValue(VerticalProperty);
+        set => SetValue(VerticalProperty, value);
     }
 
-    static void HandleVerticalSet( BindableObject bindable, object oldValue, object newValue )
+    static void HandleVerticalSet(BindableObject bindable, object oldValue, object newValue)
     {
-        if ( newValue != oldValue )
+        if (newValue != oldValue)
         {
-            ( (SliderStack)bindable ).InvalidateMeasure();
-            ( (SliderStack)bindable ).UpdateSliders();
+            ((SliderStack)bindable).InvalidateMeasure();
+            ((SliderStack)bindable).UpdateSliders();
         }
     }
 
-    public override float GetIndicatorRadiusPixels( SKSize canvasSize )
+    public override float GetIndicatorRadiusPixels(SKSize canvasSize)
     {
         // Explicit IndicatorRadiusScale > 0: derive picker radius from the LENGTH
         // axis (parallel to the slider's value direction). Thickness then becomes
         // a fixed function of radius (see GetMeasure), making the slider
         // aspect-locked.
-        if ( IndicatorRadiusScale > 0F )
+        if (IndicatorRadiusScale > 0F)
         {
             var length = Vertical ? canvasSize.Height : canvasSize.Width;
             return IndicatorRadiusScale * length;
         }
         // Auto: thickness fills available orthogonal space; picker scales to fit.
-        return ( Vertical ? canvasSize.Width : canvasSize.Height ) / _sliders.Count / 2.2F;
+        return (Vertical ? canvasSize.Width : canvasSize.Height) / _sliders.Count / 2.2F;
     }
-    public override float GetIndicatorRadiusPixels()                       => GetIndicatorRadiusPixels( GetCanvasSize() );
+    public override float GetIndicatorRadiusPixels() => GetIndicatorRadiusPixels(GetCanvasSize());
 
     protected abstract IEnumerable<SliderBase> GetSliders();
 
@@ -59,127 +59,127 @@ public abstract class SliderStack : SkiaPickerBase
     {
         _sliders.Clear();
         var i = 1;
-        foreach ( var slider in GetSliders() )
+        foreach (var slider in GetSliders())
         {
             var SliderBounds = new SliderBounds(slider)
             {
                 OffsetLocationMultiplier = (float)(-1.1 + (i * 2.2))
             };
-            _sliders.Add( SliderBounds );
+            _sliders.Add(SliderBounds);
             i++;
         }
 
         InvalidateSurface();
     }
 
-    protected override void OnPaintSurface( SKCanvas canvas, int width, int height )
+    protected override void OnPaintSurface(SKCanvas canvas, int width, int height)
     {
         var canvasSize = new SKSize(width, height);
-        UpdateLocations( SelectedColor, canvasSize );
+        UpdateLocations(SelectedColor, canvasSize);
         canvas.Clear();
 
-        foreach ( var slider in _sliders )
+        foreach (var slider in _sliders)
         {
-            PaintSlider( canvas, slider, canvasSize );
-            PaintIndicator( canvas, slider.Location );
+            PaintSlider(canvas, slider, canvasSize);
+            PaintIndicator(canvas, slider.Location);
         }
     }
 
-    protected override void OnSelectedColorChanging( Color color ) => InvalidateSurface();
+    protected override void OnSelectedColorChanging(Color color) => InvalidateSurface();
 
-    protected override void OnTouchActionPressed( TouchActionEventArgs args )
+    protected override void OnTouchActionPressed(TouchActionEventArgs args)
     {
         var canvasSize  = GetCanvasSize();
         var point       = ConvertToPixel(args.Location);
 
-        foreach ( var slider in _sliders )
+        foreach (var slider in _sliders)
         {
             var slidersOffset = slider.GetSliderOffset(GetIndicatorRadiusPixels());
-            if ( slider.LocationProgressId is null && IsInSliderArea( point, slidersOffset ) )
+            if (slider.LocationProgressId is null && IsInSliderArea(point, slidersOffset))
             {
                 slider.LocationProgressId = args.Id;
-                slider.Location = LimitToSliderLocation( point, slidersOffset, canvasSize );
-                UpdateColors( slider, canvasSize );
+                slider.Location = LimitToSliderLocation(point, slidersOffset, canvasSize);
+                UpdateColors(slider, canvasSize);
             }
         }
     }
 
-    protected override void OnTouchActionMoved( TouchActionEventArgs args )
+    protected override void OnTouchActionMoved(TouchActionEventArgs args)
     {
         var canvasSize  = GetCanvasSize();
         var point       = ConvertToPixel(args.Location);
 
-        foreach ( var slider in _sliders )
+        foreach (var slider in _sliders)
         {
-            if ( slider.LocationProgressId == args.Id )
+            if (slider.LocationProgressId == args.Id)
             {
                 var slidersOffset = slider.GetSliderOffset(GetIndicatorRadiusPixels());
-                slider.Location = LimitToSliderLocation( point, slidersOffset, canvasSize );
-                UpdateColors( slider, canvasSize );
+                slider.Location = LimitToSliderLocation(point, slidersOffset, canvasSize);
+                UpdateColors(slider, canvasSize);
             }
         }
     }
 
-    protected override void OnTouchActionReleased( TouchActionEventArgs args )
+    protected override void OnTouchActionReleased(TouchActionEventArgs args)
     {
         var canvasSize  = GetCanvasSize();
         var point       = ConvertToPixel(args.Location);
 
-        foreach ( var slider in _sliders )
+        foreach (var slider in _sliders)
         {
-            if ( slider.LocationProgressId == args.Id )
+            if (slider.LocationProgressId == args.Id)
             {
                 slider.LocationProgressId = null;
                 var slidersOffset = slider.GetSliderOffset(GetIndicatorRadiusPixels());
-                slider.Location = LimitToSliderLocation( point, slidersOffset, canvasSize );
-                UpdateColors( slider, canvasSize );
+                slider.Location = LimitToSliderLocation(point, slidersOffset, canvasSize);
+                UpdateColors(slider, canvasSize);
             }
         }
     }
 
-    protected override void OnTouchActionCancelled( TouchActionEventArgs args )
+    protected override void OnTouchActionCancelled(TouchActionEventArgs args)
     {
-        foreach ( var slider in _sliders )
+        foreach (var slider in _sliders)
         {
-            if ( slider.LocationProgressId == args.Id )
+            if (slider.LocationProgressId == args.Id)
             {
                 slider.LocationProgressId = null;
             }
         }
     }
 
-    protected override SizeRequest GetMeasure( double widthConstraint, double heightConstraint )
+    protected override SizeRequest GetMeasure(double widthConstraint, double heightConstraint)
     {
         // When IndicatorRadiusScale is explicitly set, the slider stack becomes
         // aspect-locked: the LENGTH axis fills, the THICKNESS axis is derived
         // from the picker radius. thickness = count * 2.2 * pickerRadius
         //                                   = count * 2.2 * scale * length.
-        if ( IndicatorRadiusScale > 0F )
+        if (IndicatorRadiusScale > 0F)
         {
-            if ( Vertical )
+            if (Vertical)
             {
                 // length = height, thickness = width
-                var length = double.IsInfinity( heightConstraint ) ? 200 : heightConstraint;
+                var length = double.IsInfinity(heightConstraint) ? 200 : heightConstraint;
                 var thickness = _sliders.Count * 2.2 * IndicatorRadiusScale * length;
-                if ( !double.IsInfinity( widthConstraint ) && thickness > widthConstraint )
+                if (!double.IsInfinity(widthConstraint) && thickness > widthConstraint)
                     thickness = widthConstraint;
-                return new SizeRequest( new Size( thickness, length ) );
+                return new SizeRequest(new Size(thickness, length));
             }
             else
             {
                 // length = width, thickness = height
-                var length = double.IsInfinity( widthConstraint ) ? 200 : widthConstraint;
+                var length = double.IsInfinity(widthConstraint) ? 200 : widthConstraint;
                 var thickness = _sliders.Count * 2.2 * IndicatorRadiusScale * length;
-                if ( !double.IsInfinity( heightConstraint ) && thickness > heightConstraint )
+                if (!double.IsInfinity(heightConstraint) && thickness > heightConstraint)
                     thickness = heightConstraint;
-                return new SizeRequest( new Size( length, thickness ) );
+                return new SizeRequest(new Size(length, thickness));
             }
         }
 
-        if ( double.IsPositiveInfinity( widthConstraint ) &&
-             double.IsPositiveInfinity( heightConstraint ) )
+        if (double.IsPositiveInfinity(widthConstraint) &&
+             double.IsPositiveInfinity(heightConstraint))
         {
-            if ( Vertical )
+            if (Vertical)
             {
                 widthConstraint = 200;
                 heightConstraint = 50;
@@ -193,57 +193,57 @@ public abstract class SliderStack : SkiaPickerBase
 
         double height;
         double width;
-        if ( Vertical )
+        if (Vertical)
         {
-            width = double.IsInfinity( widthConstraint ) ? heightConstraint * 0.1 * _sliders.Count : widthConstraint;
-            height = double.IsInfinity( heightConstraint ) ? 10 * width / _sliders.Count : heightConstraint;
+            width = double.IsInfinity(widthConstraint) ? heightConstraint * 0.1 * _sliders.Count : widthConstraint;
+            height = double.IsInfinity(heightConstraint) ? 10 * width / _sliders.Count : heightConstraint;
         }
         else
         {
-            height = double.IsInfinity( heightConstraint ) ? widthConstraint * 0.1 * _sliders.Count : heightConstraint;
-            width = double.IsInfinity( widthConstraint ) ? 10 * heightConstraint / _sliders.Count : widthConstraint;
+            height = double.IsInfinity(heightConstraint) ? widthConstraint * 0.1 * _sliders.Count : heightConstraint;
+            width = double.IsInfinity(widthConstraint) ? 10 * heightConstraint / _sliders.Count : widthConstraint;
         }
 
-        return new SizeRequest( new Size( width, height ) );
+        return new SizeRequest(new Size(width, height));
     }
 
-    protected override float GetSize() => GetSize( GetCanvasSize() );
+    protected override float GetSize() => GetSize(GetCanvasSize());
 
-    protected override float GetSize( SKSize canvasSize ) => Vertical ? canvasSize.Width : canvasSize.Height;
+    protected override float GetSize(SKSize canvasSize) => Vertical ? canvasSize.Width : canvasSize.Height;
 
-    void UpdateLocations( Color color, SKSize canvasSize )
+    void UpdateLocations(Color color, SKSize canvasSize)
     {
-        foreach ( var slider in _sliders )
+        foreach (var slider in _sliders)
         {
-            if ( slider.LocationProgressId is null )
+            if (slider.LocationProgressId is null)
             {
                 var pr = GetIndicatorRadiusPixels();
-                var left = ( pr * 1.1F ) + (SlidersWidht(canvasSize) * slider.Slider.NewValue(color));
+                var left = (pr * 1.1F) + (SlidersWidht(canvasSize) * slider.Slider.NewValue(color));
                 slider.Location = Vertical
-                    ? new SKPoint( slider.GetSliderOffset( pr ), left )
-                    : new SKPoint( left, slider.GetSliderOffset( pr ) );
+                    ? new SKPoint(slider.GetSliderOffset(pr), left)
+                    : new SKPoint(left, slider.GetSliderOffset(pr));
             }
         }
     }
 
-    float SlidersWidht( SKSize canvasSize ) 
-       => Vertical ? canvasSize.Height - ( GetIndicatorRadiusPixels() * 2.2F )
-                   : canvasSize.Width - ( GetIndicatorRadiusPixels() * 2.2F );
+    float SlidersWidht(SKSize canvasSize)
+       => Vertical ? canvasSize.Height - (GetIndicatorRadiusPixels() * 2.2F)
+                   : canvasSize.Width - (GetIndicatorRadiusPixels() * 2.2F);
 
-    void UpdateColors( SliderBounds slider, SKSize canvasSize )
+    void UpdateColors(SliderBounds slider, SKSize canvasSize)
     {
         var newColor = SelectedColor;
         var pr = GetIndicatorRadiusPixels();
-        var newValue = Vertical ? ( slider.Location.Y - ( pr * 1.1F ) ) / SlidersWidht( canvasSize )
-                                : ( slider.Location.X - ( pr * 1.1F ) ) / SlidersWidht( canvasSize );
+        var newValue = Vertical ? (slider.Location.Y - (pr * 1.1F)) / SlidersWidht(canvasSize)
+                                : (slider.Location.X - (pr * 1.1F)) / SlidersWidht(canvasSize);
 
-        newColor = slider.Slider.GetNewColor( newValue, newColor );
+        newColor = slider.Slider.GetNewColor(newValue, newColor);
 
         SelectedColor = newColor;
         InvalidateSurface();
     }
 
-    void PaintSlider( SKCanvas canvas, SliderBounds slider, SKSize canvasSize )
+    void PaintSlider(SKCanvas canvas, SliderBounds slider, SKSize canvasSize)
     {
         var pickerRadiusPixels = GetIndicatorRadiusPixels();
         var sliderTop = slider.GetSliderOffset(pickerRadiusPixels);
@@ -251,49 +251,49 @@ public abstract class SliderStack : SkiaPickerBase
         SKPoint startPoint;
         SKPoint endPoint;
 
-        if ( Vertical )
+        if (Vertical)
         {
-            startPoint = new SKPoint( sliderTop, pickerRadiusPixels * 1.1F );
-            endPoint = new SKPoint( sliderTop, canvasSize.Height - ( pickerRadiusPixels * 1.1F ) );
+            startPoint = new SKPoint(sliderTop, pickerRadiusPixels * 1.1F);
+            endPoint = new SKPoint(sliderTop, canvasSize.Height - (pickerRadiusPixels * 1.1F));
         }
         else
         {
-            startPoint = new SKPoint( pickerRadiusPixels * 1.1F, sliderTop );
-            endPoint = new SKPoint( canvasSize.Width - ( pickerRadiusPixels * 1.1F ), sliderTop );
+            startPoint = new SKPoint(pickerRadiusPixels * 1.1F, sliderTop);
+            endPoint = new SKPoint(canvasSize.Width - (pickerRadiusPixels * 1.1F), sliderTop);
         }
 
         var paint = slider.Slider.GetPaint(SelectedColor, startPoint, endPoint);
         paint.StrokeWidth = pickerRadiusPixels * 1.3F;
 
-        if ( slider.Slider.PaintChessPattern )
+        if (slider.Slider.PaintChessPattern)
         {
-            PaintChessPattern( canvas, slider, canvasSize );
+            PaintChessPattern(canvas, slider, canvasSize);
         }
 
-        canvas.DrawLine( startPoint, endPoint, paint );
+        canvas.DrawLine(startPoint, endPoint, paint);
     }
 
-    void PaintChessPattern( SKCanvas canvas, SliderBounds slider, SKSize canvasSize )
+    void PaintChessPattern(SKCanvas canvas, SliderBounds slider, SKSize canvasSize)
     {
         var pickerRadiusPixels  = GetIndicatorRadiusPixels();
         var sliderTop           = slider.GetSliderOffset(pickerRadiusPixels);
         var scale               = pickerRadiusPixels / 3;
         var path                = new SKPath();
 
-        path.MoveTo( -1 * scale, -1 * scale );
-        path.LineTo(  0 * scale, -1 * scale );
-        path.LineTo(  0 * scale,  0 * scale );
-        path.LineTo(  1 * scale,  0 * scale );
-        path.LineTo(  1 * scale,  1 * scale );
-        path.LineTo(  0 * scale,  1 * scale );
-        path.LineTo(  0 * scale,  0 * scale );
-        path.LineTo( -1 * scale,  0 * scale );
-        path.LineTo( -1 * scale, -1 * scale );
+        path.MoveTo(-1 * scale, -1 * scale);
+        path.LineTo(0 * scale, -1 * scale);
+        path.LineTo(0 * scale, 0 * scale);
+        path.LineTo(1 * scale, 0 * scale);
+        path.LineTo(1 * scale, 1 * scale);
+        path.LineTo(0 * scale, 1 * scale);
+        path.LineTo(0 * scale, 0 * scale);
+        path.LineTo(-1 * scale, 0 * scale);
+        path.LineTo(-1 * scale, -1 * scale);
 
-        var matrix = SKMatrix.CreateScale( 2 * scale, 2 * scale );
+        var matrix = SKMatrix.CreateScale(2 * scale, 2 * scale);
         var paint = new SKPaint
         {
-            PathEffect = SKPathEffect.Create2DPath( matrix, path ),
+            PathEffect = SKPathEffect.Create2DPath(matrix, path),
             Color = Colors.LightGray.ToSKColor(),
             IsAntialias = true
         };
@@ -306,39 +306,39 @@ public abstract class SliderStack : SkiaPickerBase
         // (thickness = 1.3*pr) extends 0.65*pr beyond each endpoint, so the visible
         // pill spans [pr*0.45, length - pr*0.45]. Chess clip must match that pill.
         float endInset = pickerRadiusPixels * 0.45F;
-        if ( Vertical )
+        if (Vertical)
         {
-            patternRect = new SKRect( sliderTop - pickerRadiusPixels, endInset
-                   , sliderTop + pickerRadiusPixels, canvasSize.Height - endInset );
-            clipRect = new SKRect( sliderTop - ( pickerRadiusPixels * 0.65f ), endInset
-                 , sliderTop + ( pickerRadiusPixels * 0.65f ), canvasSize.Height - endInset );
-            clipRoundRect = new SKRoundRect( clipRect, pickerRadiusPixels * 0.65f, pickerRadiusPixels * 0.65f );
+            patternRect = new SKRect(sliderTop - pickerRadiusPixels, endInset
+                   , sliderTop + pickerRadiusPixels, canvasSize.Height - endInset);
+            clipRect = new SKRect(sliderTop - (pickerRadiusPixels * 0.65f), endInset
+                 , sliderTop + (pickerRadiusPixels * 0.65f), canvasSize.Height - endInset);
+            clipRoundRect = new SKRoundRect(clipRect, pickerRadiusPixels * 0.65f, pickerRadiusPixels * 0.65f);
         }
         else
         {
-            patternRect = new SKRect( endInset, sliderTop - pickerRadiusPixels
-               , canvasSize.Width - endInset, sliderTop + pickerRadiusPixels );
-            clipRect = new SKRect( endInset, sliderTop - ( pickerRadiusPixels * 0.65f )
-               , canvasSize.Width - endInset, sliderTop + ( pickerRadiusPixels * 0.65f ) );
-            clipRoundRect = new SKRoundRect( clipRect, pickerRadiusPixels * 0.65f, pickerRadiusPixels * 0.65f );
+            patternRect = new SKRect(endInset, sliderTop - pickerRadiusPixels
+               , canvasSize.Width - endInset, sliderTop + pickerRadiusPixels);
+            clipRect = new SKRect(endInset, sliderTop - (pickerRadiusPixels * 0.65f)
+               , canvasSize.Width - endInset, sliderTop + (pickerRadiusPixels * 0.65f));
+            clipRoundRect = new SKRoundRect(clipRect, pickerRadiusPixels * 0.65f, pickerRadiusPixels * 0.65f);
         }
 
         canvas.Save();
-        canvas.ClipRoundRect( clipRoundRect );
-        canvas.DrawRect( patternRect, paint );
+        canvas.ClipRoundRect(clipRoundRect);
+        canvas.DrawRect(patternRect, paint);
         canvas.Restore();
     }
 
-    bool IsInSliderArea( SKPoint point, float slidersHeight ) 
+    bool IsInSliderArea(SKPoint point, float slidersHeight)
             => Vertical ? point.X >= slidersHeight - GetIndicatorRadiusPixels() && point.X <= slidersHeight + GetIndicatorRadiusPixels()
                         : point.Y >= slidersHeight - GetIndicatorRadiusPixels() && point.Y <= slidersHeight + GetIndicatorRadiusPixels();
 
-    SKPoint LimitToSliderLocation( SKPoint point, float slidersOffset, SKSize canvasSize )
+    SKPoint LimitToSliderLocation(SKPoint point, float slidersOffset, SKSize canvasSize)
     {
-        var result = new SKPoint( point.X, point.Y );
+        var result = new SKPoint(point.X, point.Y);
         var endMargin = GetIndicatorRadiusPixels() * 1.1F;
 
-        if ( Vertical )
+        if (Vertical)
         {
             result.Y = result.Y >= endMargin ? result.Y : endMargin;
             result.Y = result.Y <= canvasSize.Height - endMargin ? result.Y

--- a/ColorPicker/BaseClasses/SliderStackWithAlpha.cs
+++ b/ColorPicker/BaseClasses/SliderStackWithAlpha.cs
@@ -2,23 +2,23 @@ namespace ColorPicker.BaseClasses;
 
 public abstract class SliderStackWithAlpha : SliderStack
 {
-    public static readonly BindableProperty ShowAlphaSliderProperty 
-                         = BindableProperty.Create( nameof(ShowAlphaSlider),
+    public static readonly BindableProperty ShowAlphaSliderProperty
+                         = BindableProperty.Create(nameof(ShowAlphaSlider),
                                                     typeof(bool),
                                                     typeof(SliderStackWithAlpha),
                                                     true,
-                                                    propertyChanged: HandleShowLuminositySet );
+                                                    propertyChanged: HandleShowLuminositySet);
     public bool ShowAlphaSlider
     {
-        get => (bool)GetValue( ShowAlphaSliderProperty );
-        set => SetValue( ShowAlphaSliderProperty, value );
+        get => (bool)GetValue(ShowAlphaSliderProperty);
+        set => SetValue(ShowAlphaSliderProperty, value);
     }
 
-    static void HandleShowLuminositySet( BindableObject bindable, object oldValue, object newValue )
+    static void HandleShowLuminositySet(BindableObject bindable, object oldValue, object newValue)
     {
-        if ( newValue != oldValue )
+        if (newValue != oldValue)
         {
-            ( (SliderStackWithAlpha)bindable ).UpdateSliders();
+            ((SliderStackWithAlpha)bindable).UpdateSliders();
         }
     }
 }

--- a/ColorPicker/Behaviors/TouchActionEventArgs.cs
+++ b/ColorPicker/Behaviors/TouchActionEventArgs.cs
@@ -2,16 +2,16 @@ namespace ColorPicker.Behaviors;
 
 public class TouchActionEventArgs : EventArgs
 {
-    public long     Id                      { get; }
-    public Point    Location                { get; }
-    public bool     IsInContact             { get; }
-    public TouchActionType Type  { get; }
+    public long Id { get; }
+    public Point Location { get; }
+    public bool IsInContact { get; }
+    public TouchActionType Type { get; }
 
-    public TouchActionEventArgs( long id, TouchActionType type, Point location, bool isInContact )
+    public TouchActionEventArgs(long id, TouchActionType type, Point location, bool isInContact)
     {
-        Id          = id;
-        Location    = location;
+        Id = id;
+        Location = location;
         IsInContact = isInContact;
-        Type        = type;
+        Type = type;
     }
 }

--- a/ColorPicker/Behaviors/TouchBehavior.cs
+++ b/ColorPicker/Behaviors/TouchBehavior.cs
@@ -2,11 +2,11 @@ namespace ColorPicker.Behaviors;
 
 public class TouchBehavior : Behavior
 {
-    public delegate void ColorPickerTouchActionEventHandler( object sender, TouchActionEventArgs args );
+    public delegate void ColorPickerTouchActionEventHandler(object sender, TouchActionEventArgs args);
 
     public bool Capture { set; get; }
     public event ColorPickerTouchActionEventHandler TouchAction;
 
-    public void OnTouchAction( Element element, TouchActionEventArgs args )
-             => TouchAction?.Invoke( element, args );
+    public void OnTouchAction(Element element, TouchActionEventArgs args)
+             => TouchAction?.Invoke(element, args);
 }

--- a/ColorPicker/Classes/ColorChangedEventArgs.cs
+++ b/ColorPicker/Classes/ColorChangedEventArgs.cs
@@ -5,7 +5,7 @@ public class ColorChangedEventArgs : EventArgs
     public Color OldColor { get; }
     public Color NewColor { get; }
 
-    public ColorChangedEventArgs( Color oldColor, Color newColor )
+    public ColorChangedEventArgs(Color oldColor, Color newColor)
     {
         OldColor = oldColor;
         NewColor = newColor;

--- a/ColorPicker/Classes/MauiAppBuilderExtensions.cs
+++ b/ColorPicker/Classes/MauiAppBuilderExtensions.cs
@@ -7,8 +7,8 @@ public static class MauiAppBuilderExtensions
     /// <summary>
     /// Use this to register SkiaSharp and ColorPicker controls
     /// </summary>
-    public static MauiAppBuilder UseColorPickersAndSliders( this MauiAppBuilder builder )
-    {   
+    public static MauiAppBuilder UseColorPickersAndSliders(this MauiAppBuilder builder)
+    {
         //  Using SkiaSharp
         //
         builder.UseSkiaSharp();

--- a/ColorPicker/Classes/PolarPoint.cs
+++ b/ColorPicker/Classes/PolarPoint.cs
@@ -6,16 +6,16 @@ public class PolarPoint
     public float Angle
     {
         get => _angle;
-        set => _angle = (float)Math.Atan2( Math.Sin( value ), Math.Cos( value ) );
+        set => _angle = (float)Math.Atan2(Math.Sin(value), Math.Cos(value));
     }
 
     public float Radius { get; set; }
 
-    public PolarPoint( float radius, float angle )
+    public PolarPoint(float radius, float angle)
     {
         Radius = radius;
         Angle = angle;
     }
 
-    public override string ToString() => string.Format( "Radius: {0}; Angle: {1}", Radius, Angle );
+    public override string ToString() => string.Format("Radius: {0}; Angle: {1}", Radius, Angle);
 }

--- a/ColorPicker/Classes/SliderBounds.cs
+++ b/ColorPicker/Classes/SliderBounds.cs
@@ -2,13 +2,13 @@ namespace ColorPicker.Classes;
 
 public class SliderBounds
 {
-    public SliderBounds( SliderBase slider )  => Slider = slider;
+    public SliderBounds(SliderBase slider) => Slider = slider;
 
-    public SliderBase   Slider                      { get; }
+    public SliderBase Slider { get; }
 
-    public long?        LocationProgressId          { get; set; }
-    public float        OffsetLocationMultiplier    { get; set; }
-    public SKPoint      Location                    { get; set; } = new SKPoint();
+    public long? LocationProgressId { get; set; }
+    public float OffsetLocationMultiplier { get; set; }
+    public SKPoint Location { get; set; } = new SKPoint();
 
-    public float GetSliderOffset( float PickerRadiusPixels )  => PickerRadiusPixels * OffsetLocationMultiplier;
+    public float GetSliderOffset(float PickerRadiusPixels) => PickerRadiusPixels * OffsetLocationMultiplier;
 }

--- a/ColorPicker/Controls/AlphaSlider.cs
+++ b/ColorPicker/Controls/AlphaSlider.cs
@@ -2,12 +2,12 @@ namespace ColorPicker.Controls;
 
 public class AlphaSlider : SliderStack
 {
-    protected override IEnumerable<SliderBase> GetSliders() 
+    protected override IEnumerable<SliderBase> GetSliders()
         => new SliderBase[]
         {
-            new DelegateSlider( AlphaSliderFactory.NewValueAlpha,
+            new DelegateSlider(AlphaSliderFactory.NewValueAlpha,
                         AlphaSliderFactory.GetNewColorAlpha,
-                        AlphaSliderFactory.GetPaintAlpha )
+                        AlphaSliderFactory.GetPaintAlpha)
             {
                 PaintChessPattern = true
             }

--- a/ColorPicker/Controls/AlphaSliderFactory.cs
+++ b/ColorPicker/Controls/AlphaSliderFactory.cs
@@ -2,19 +2,19 @@ namespace ColorPicker.Controls;
 
 public static class AlphaSliderFactory
 {
-    public static float NewValueAlpha( Color color ) => (float)color.Alpha;
+    public static float NewValueAlpha(Color color) => (float)color.Alpha;
 
-    public static Color GetNewColorAlpha( float newValue, Color oldColor )
-        => Color.FromRgba( oldColor.Red, oldColor.Green, oldColor.Blue, newValue );
+    public static Color GetNewColorAlpha(float newValue, Color oldColor)
+        => Color.FromRgba(oldColor.Red, oldColor.Green, oldColor.Blue, newValue);
 
-    public static SKPaint GetPaintAlpha( Color color, SKPoint startPoint, SKPoint endPoint )
+    public static SKPaint GetPaintAlpha(Color color, SKPoint startPoint, SKPoint endPoint)
     {
         var startColor = Color.FromRgba(color.Red, color.Green, color.Blue, 0).ToSKColor();
         var endColor = Color.FromRgba(color.Red, color.Green, color.Blue, 1).ToSKColor();
-        return GetPaint( startColor, endColor, startPoint, endPoint );
+        return GetPaint(startColor, endColor, startPoint, endPoint);
     }
 
-    public static SKPaint GetPaint( SKColor startColor, SKColor endColor, SKPoint startPoint, SKPoint endPoint )
+    public static SKPaint GetPaint(SKColor startColor, SKColor endColor, SKPoint startPoint, SKPoint endPoint)
     {
         var paint = new SKPaint()
         {

--- a/ColorPicker/Controls/ColorDisc.cs
+++ b/ColorPicker/Controls/ColorDisc.cs
@@ -10,39 +10,39 @@ public class ColorDisc : SkiaPickerBase
 
     readonly SKColor[] _sweepGradientColors = new SKColor[256];
 
-    public static readonly BindableProperty ShowLuminosityRingProperty 
-                         = BindableProperty.Create( nameof(ShowLuminosityRing),
+    public static readonly BindableProperty ShowLuminosityRingProperty
+                         = BindableProperty.Create(nameof(ShowLuminosityRing),
                                                     typeof(bool),
                                                     typeof(ColorDisc),
                                                     true,
-                                                    propertyChanged: HandleShowLuminosity );
+                                                    propertyChanged: HandleShowLuminosity);
     public bool ShowLuminosityRing
     {
-        get => (bool)GetValue( ShowLuminosityRingProperty );
-        set => SetValue( ShowLuminosityRingProperty, value );
+        get => (bool)GetValue(ShowLuminosityRingProperty);
+        set => SetValue(ShowLuminosityRingProperty, value);
     }
-    static void HandleShowLuminosity( BindableObject bindable, object oldValue, object newValue )
+    static void HandleShowLuminosity(BindableObject bindable, object oldValue, object newValue)
     {
-        if ( newValue != oldValue )
-            ( (ColorDisc)bindable ).InvalidateSurface();
+        if (newValue != oldValue)
+            ((ColorDisc)bindable).InvalidateSurface();
     }
 
-    public static readonly BindableProperty CanvasBackgroundColorProperty 
-                         = BindableProperty.Create( nameof(CanvasBackgroundColor),
+    public static readonly BindableProperty CanvasBackgroundColorProperty
+                         = BindableProperty.Create(nameof(CanvasBackgroundColor),
                                                     typeof(Color),
                                                     typeof(ColorDisc),
                                                     Colors.Transparent,
-                                                    propertyChanged: HandleCanvasBackgroundColor );
+                                                    propertyChanged: HandleCanvasBackgroundColor);
     public Color CanvasBackgroundColor
     {
-        get => (Color)GetValue( CanvasBackgroundColorProperty );
-        set => SetValue( CanvasBackgroundColorProperty, value );
+        get => (Color)GetValue(CanvasBackgroundColorProperty);
+        set => SetValue(CanvasBackgroundColorProperty, value);
     }
-    static void HandleCanvasBackgroundColor( BindableObject bindable, object oldValue, object newValue )
+    static void HandleCanvasBackgroundColor(BindableObject bindable, object oldValue, object newValue)
     {
-        if ( newValue != oldValue )
+        if (newValue != oldValue)
         {
-            ( (ColorDisc)bindable ).InvalidateSurface();
+            ((ColorDisc)bindable).InvalidateSurface();
         }
     }
 
@@ -51,168 +51,168 @@ public class ColorDisc : SkiaPickerBase
     /// </summary>
     public ColorDisc()
     {
-        for ( var i = 128; i >= -127; i-- )
-            _sweepGradientColors[ 255 - ( i + 127 ) ] = Color.FromHsla( ( i < 0 ? 255 + i : i ) / 255D, 1, 0.5 ).ToSKColor();
+        for (var i = 128; i >= -127; i--)
+            _sweepGradientColors[255 - (i + 127)] = Color.FromHsla((i < 0 ? 255 + i : i) / 255D, 1, 0.5).ToSKColor();
     }
 
-    public override float GetIndicatorRadiusPixels() => GetIndicatorRadiusPixels( GetCanvasSize() );
-    public override float GetIndicatorRadiusPixels( SKSize canvasSize ) => GetSize( canvasSize ) * IndicatorRadiusScale;
+    public override float GetIndicatorRadiusPixels() => GetIndicatorRadiusPixels(GetCanvasSize());
+    public override float GetIndicatorRadiusPixels(SKSize canvasSize) => GetSize(canvasSize) * IndicatorRadiusScale;
 
-    protected override void OnTouchActionPressed( TouchActionEventArgs args )
+    protected override void OnTouchActionPressed(TouchActionEventArgs args)
     {
         var canvasRadius    = GetCanvasSize().Width / 2F;
         var point           = ConvertToPixel(args.Location);
 
-        if ( _locationHsProgressId is null && IsInHsArea( point, canvasRadius ) )
+        if (_locationHsProgressId is null && IsInHsArea(point, canvasRadius))
         {
-            _locationHsProgressId    = args.Id;
-            _locationHs              = LimitToHsRadius( point, canvasRadius );
-            UpdateColors( canvasRadius );
+            _locationHsProgressId = args.Id;
+            _locationHs = LimitToHsRadius(point, canvasRadius);
+            UpdateColors(canvasRadius);
         }
-        else if ( _locationLProgressId is null && IsInLArea( point, canvasRadius ) )
+        else if (_locationLProgressId is null && IsInLArea(point, canvasRadius))
         {
-            _locationLProgressId     = args.Id;
-            _locationL               = LimitToLRadius( point, canvasRadius );
-            UpdateColors( canvasRadius );
+            _locationLProgressId = args.Id;
+            _locationL = LimitToLRadius(point, canvasRadius);
+            UpdateColors(canvasRadius);
         }
     }
 
-    protected override void OnTouchActionMoved( TouchActionEventArgs args )
+    protected override void OnTouchActionMoved(TouchActionEventArgs args)
     {
         var canvasRadius    = GetCanvasSize().Width / 2F;
         var point           = ConvertToPixel(args.Location);
 
-        if ( _locationHsProgressId == args.Id )
+        if (_locationHsProgressId == args.Id)
         {
-            _locationHs = LimitToHsRadius( point, canvasRadius );
-            UpdateColors( canvasRadius );
+            _locationHs = LimitToHsRadius(point, canvasRadius);
+            UpdateColors(canvasRadius);
         }
-        else if ( _locationLProgressId == args.Id )
+        else if (_locationLProgressId == args.Id)
         {
-            _locationL = LimitToLRadius( point, canvasRadius );
-            UpdateColors( canvasRadius );
+            _locationL = LimitToLRadius(point, canvasRadius);
+            UpdateColors(canvasRadius);
         }
     }
 
-    protected override void OnTouchActionReleased( TouchActionEventArgs args )
+    protected override void OnTouchActionReleased(TouchActionEventArgs args)
     {
         var canvasRadius    = GetCanvasSize().Width / 2F;
         var point           = ConvertToPixel(args.Location);
 
-        if ( _locationHsProgressId == args.Id )
+        if (_locationHsProgressId == args.Id)
         {
-            _locationHsProgressId    = null;
-            _locationHs              = LimitToHsRadius( point, canvasRadius );
-            UpdateColors( canvasRadius );
-        }
-        else if ( _locationLProgressId == args.Id )
-        {
-            _locationLProgressId     = null;
-            _locationL               = LimitToLRadius( point, canvasRadius );
-            UpdateColors( canvasRadius );
-        }
-    }
-
-    protected override void OnTouchActionCancelled( TouchActionEventArgs args )
-    {
-        if ( _locationHsProgressId == args.Id )
             _locationHsProgressId = null;
-        else if ( _locationLProgressId == args.Id )
+            _locationHs = LimitToHsRadius(point, canvasRadius);
+            UpdateColors(canvasRadius);
+        }
+        else if (_locationLProgressId == args.Id)
+        {
+            _locationLProgressId = null;
+            _locationL = LimitToLRadius(point, canvasRadius);
+            UpdateColors(canvasRadius);
+        }
+    }
+
+    protected override void OnTouchActionCancelled(TouchActionEventArgs args)
+    {
+        if (_locationHsProgressId == args.Id)
+            _locationHsProgressId = null;
+        else if (_locationLProgressId == args.Id)
             _locationLProgressId = null;
     }
 
-    protected override void OnPaintSurface( SKCanvas canvas, int width, int height )
+    protected override void OnPaintSurface(SKCanvas canvas, int width, int height)
     {
         var canvasRadius = GetSize() / 2F;
 
-        UpdateLocations( SelectedColor, canvasRadius );
+        UpdateLocations(SelectedColor, canvasRadius);
         canvas.Clear();
-        PaintBackground( canvas, canvasRadius );
+        PaintBackground(canvas, canvasRadius);
 
-        if ( ShowLuminosityRing )
+        if (ShowLuminosityRing)
         {
-            PaintLGradient( canvas, canvasRadius );
-            PaintIndicator( canvas, _locationL );
+            PaintLGradient(canvas, canvasRadius);
+            PaintIndicator(canvas, _locationL);
         }
 
-        PaintColorSweepGradient( canvas, canvasRadius );
-        PaintGrayRadialGradient( canvas, canvasRadius );
-        PaintIndicator( canvas, _locationHs );
+        PaintColorSweepGradient(canvas, canvasRadius);
+        PaintGrayRadialGradient(canvas, canvasRadius);
+        PaintIndicator(canvas, _locationHs);
     }
 
-    protected override void OnSelectedColorChanging( Color color ) 
+    protected override void OnSelectedColorChanging(Color color)
             => InvalidateSurface();
 
-    protected override SizeRequest GetMeasure( double widthConstraint, double heightConstraint )
+    protected override SizeRequest GetMeasure(double widthConstraint, double heightConstraint)
     {
-        if ( double.IsPositiveInfinity( widthConstraint ) &&
-             double.IsPositiveInfinity( heightConstraint ) )
+        if (double.IsPositiveInfinity(widthConstraint) &&
+             double.IsPositiveInfinity(heightConstraint))
         {
-            widthConstraint  = 200;
+            widthConstraint = 200;
             heightConstraint = 200;
         }
 
-        var size = Math.Min( widthConstraint, heightConstraint );
+        var size = Math.Min(widthConstraint, heightConstraint);
 
-        return new SizeRequest( new Size( size, size ) );
+        return new SizeRequest(new Size(size, size));
     }
 
-    protected override float GetSize( SKSize canvasSize )   => canvasSize.Width;
-    protected override float GetSize()                      => GetSize( GetCanvasSize() );
+    protected override float GetSize(SKSize canvasSize) => canvasSize.Width;
+    protected override float GetSize() => GetSize(GetCanvasSize());
 
-    void UpdateLocations( Color color, float canvasRadius )
+    void UpdateLocations(Color color, float canvasRadius)
     {
-        if ( color.GetLuminosity() != 0 || !IsInHsArea( _locationHs, canvasRadius ) )
+        if (color.GetLuminosity() != 0 || !IsInHsArea(_locationHs, canvasRadius))
         {
             var angleHs  = (0.5 - color.GetHue()) * (2 * Math.PI);
             var radiusHs = HsRadius(canvasRadius) * color.GetSaturation();
 
-            var resultHs = FromPolar(new PolarPoint( (float)radiusHs, (float)angleHs) );
-            resultHs.X  += canvasRadius;
-            resultHs.Y  += canvasRadius;
-            _locationHs   = resultHs;
+            var resultHs = FromPolar(new PolarPoint((float)radiusHs, (float)angleHs));
+            resultHs.X += canvasRadius;
+            resultHs.Y += canvasRadius;
+            _locationHs = resultHs;
         }
 
         var polarL      = ToPolar(ToLCoordinates(_locationL, canvasRadius));
-        polarL.Angle   -= (float)Math.PI / 2F;
+        polarL.Angle -= (float)Math.PI / 2F;
         var signOld     = polarL.Angle <= 0 ? 1 : -1;
         var angleL      = color.GetLuminosity() * Math.PI * signOld;
 
-        var resultL     = FromPolar( new PolarPoint( LRadius(canvasRadius), (float)(angleL - (Math.PI / 2)) ) );
-        resultL.X      += canvasRadius;
-        resultL.Y      += canvasRadius;
-        _locationL       = resultL;
+        var resultL     = FromPolar(new PolarPoint(LRadius(canvasRadius), (float)(angleL - (Math.PI / 2))));
+        resultL.X += canvasRadius;
+        resultL.Y += canvasRadius;
+        _locationL = resultL;
     }
 
-    void UpdateColors( float canvasRadius )
+    void UpdateColors(float canvasRadius)
     {
         var hsPoint    = ToHsCoordinates(_locationHs, canvasRadius);
         var lPoint     = ToLCoordinates(_locationL, canvasRadius);
 
         var newColor        = WheelPointToColor(hsPoint, lPoint);
-        SelectedColor       = newColor;
+        SelectedColor = newColor;
     }
 
-    bool IsInHsArea( SKPoint point, float canvasRadius )
+    bool IsInHsArea(SKPoint point, float canvasRadius)
     {
-        var polar = ToPolar( new SKPoint( point.X - canvasRadius, point.Y - canvasRadius ) );
-        return polar.Radius <= HsRadius( canvasRadius );
+        var polar = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
+        return polar.Radius <= HsRadius(canvasRadius);
     }
 
-    bool IsInLArea( SKPoint point, float canvasRadius )
+    bool IsInLArea(SKPoint point, float canvasRadius)
     {
-        if ( !ShowLuminosityRing )
+        if (!ShowLuminosityRing)
             return false;
 
         var polar = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
 
-        return polar.Radius <= LRadius( canvasRadius ) + ( GetIndicatorRadiusPixels() / 2F )
-            && polar.Radius >= LRadius( canvasRadius ) - ( GetIndicatorRadiusPixels() / 2F );
+        return polar.Radius <= LRadius(canvasRadius) + (GetIndicatorRadiusPixels() / 2F)
+            && polar.Radius >= LRadius(canvasRadius) - (GetIndicatorRadiusPixels() / 2F);
     }
 
-    void PaintBackground( SKCanvas canvas, float canvasRadius )
+    void PaintBackground(SKCanvas canvas, float canvasRadius)
     {
-        var center = new SKPoint( canvasRadius, canvasRadius );
+        var center = new SKPoint(canvasRadius, canvasRadius);
 
         var paint = new SKPaint
         {
@@ -220,12 +220,12 @@ public class ColorDisc : SkiaPickerBase
             Color = CanvasBackgroundColor.ToSKColor()
         };
 
-        canvas.DrawCircle( center, canvasRadius - GetIndicatorRadiusPixels(), paint );
+        canvas.DrawCircle(center, canvasRadius - GetIndicatorRadiusPixels(), paint);
     }
 
-    void PaintLGradient( SKCanvas canvas, float canvasRadius )
+    void PaintLGradient(SKCanvas canvas, float canvasRadius)
     {
-        var center = new SKPoint( canvasRadius, canvasRadius );
+        var center = new SKPoint(canvasRadius, canvasRadius);
 
         var colors = new List<SKColor>()
         {
@@ -236,7 +236,7 @@ public class ColorDisc : SkiaPickerBase
             Color.FromHsla(SelectedColor.GetHue(), SelectedColor.GetSaturation(), 0.5).ToSKColor()
         };
 
-        var shader = SKShader.CreateSweepGradient( center, colors.ToArray(), null );
+        var shader = SKShader.CreateSweepGradient(center, colors.ToArray(), null);
 
         var paint = new SKPaint
         {
@@ -245,14 +245,14 @@ public class ColorDisc : SkiaPickerBase
             Style       = SKPaintStyle.Stroke,
             StrokeWidth = GetIndicatorRadiusPixels()
         };
-        canvas.DrawCircle( center, LRadius( canvasRadius ), paint );
+        canvas.DrawCircle(center, LRadius(canvasRadius), paint);
     }
 
-    void PaintColorSweepGradient( SKCanvas canvas, float canvasRadius )
+    void PaintColorSweepGradient(SKCanvas canvas, float canvasRadius)
     {
-        var center = new SKPoint( canvasRadius, canvasRadius );
+        var center = new SKPoint(canvasRadius, canvasRadius);
 
-        var shader = SKShader.CreateSweepGradient( center, _sweepGradientColors, null );
+        var shader = SKShader.CreateSweepGradient(center, _sweepGradientColors, null);
 
         var paint = new SKPaint
         {
@@ -260,20 +260,20 @@ public class ColorDisc : SkiaPickerBase
             Shader      = shader,
             Style       = SKPaintStyle.Fill
         };
-        canvas.DrawCircle( center, HsRadius( canvasRadius ), paint );
+        canvas.DrawCircle(center, HsRadius(canvasRadius), paint);
     }
 
-    void PaintGrayRadialGradient( SKCanvas canvas, float canvasRadius )
+    void PaintGrayRadialGradient(SKCanvas canvas, float canvasRadius)
     {
         var center = new SKPoint(canvasRadius, canvasRadius);
 
-        var colors = new SKColor[] 
+        var colors = new SKColor[]
         {
             SKColors.Gray,
             SKColors.Transparent
         };
 
-        var shader = SKShader.CreateRadialGradient( center, HsRadius(canvasRadius), colors, null, SKShaderTileMode.Clamp );
+        var shader = SKShader.CreateRadialGradient(center, HsRadius(canvasRadius), colors, null, SKShaderTileMode.Clamp);
 
         var paint = new SKPaint
         {
@@ -281,96 +281,96 @@ public class ColorDisc : SkiaPickerBase
             Shader      = shader,
             Style       = SKPaintStyle.Fill
         };
-        canvas.DrawPaint( paint );
+        canvas.DrawPaint(paint);
     }
 
-    SKPoint ToHsCoordinates( SKPoint point, float canvasRadius )
+    SKPoint ToHsCoordinates(SKPoint point, float canvasRadius)
     {
-        var result = new SKPoint( point.X, point.Y );
+        var result = new SKPoint(point.X, point.Y);
 
-        result.X  -= canvasRadius;
-        result.Y  -= canvasRadius;
-        result.X  /= HsRadius( canvasRadius );
-        result.Y  /= HsRadius( canvasRadius );
+        result.X -= canvasRadius;
+        result.Y -= canvasRadius;
+        result.X /= HsRadius(canvasRadius);
+        result.Y /= HsRadius(canvasRadius);
 
         return result;
     }
 
-    SKPoint ToLCoordinates( SKPoint point, float canvasRadius )
+    SKPoint ToLCoordinates(SKPoint point, float canvasRadius)
     {
-        var result = new SKPoint( point.X, point.Y );
+        var result = new SKPoint(point.X, point.Y);
 
-        result.X  -= canvasRadius;
-        result.Y  -= canvasRadius;
-        result.X  /= LRadius( canvasRadius );
-        result.Y  /= LRadius( canvasRadius );
+        result.X -= canvasRadius;
+        result.Y -= canvasRadius;
+        result.X /= LRadius(canvasRadius);
+        result.Y /= LRadius(canvasRadius);
 
         return result;
     }
 
-    Color WheelPointToColor( SKPoint pointHS, SKPoint pointL )
+    Color WheelPointToColor(SKPoint pointHS, SKPoint pointL)
     {
         var polarHS     = ToPolar(pointHS);
         var polarL      = ToPolar(pointL);
 
-        polarL.Angle   += (float)Math.PI / 2F;
-        polarL          = ToPolar( FromPolar( polarL ) );
+        polarL.Angle += (float)Math.PI / 2F;
+        polarL = ToPolar(FromPolar(polarL));
 
         var h   = (Math.PI - polarHS.Angle) / (2 * Math.PI);
         var s   = polarHS.Radius;
         var l   = Math.Abs(polarL.Angle) / Math.PI;
 
-        return Color.FromHsla( h, s, l, SelectedColor.Alpha );
+        return Color.FromHsla(h, s, l, SelectedColor.Alpha);
     }
 
-    SKPoint LimitToHsRadius( SKPoint point, float canvasRadius )
+    SKPoint LimitToHsRadius(SKPoint point, float canvasRadius)
     {
         var polar       = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
-        polar.Radius    = polar.Radius < HsRadius( canvasRadius ) ? polar.Radius : HsRadius( canvasRadius );
+        polar.Radius = polar.Radius < HsRadius(canvasRadius) ? polar.Radius : HsRadius(canvasRadius);
         var result      = FromPolar(polar);
 
-        result.X       += canvasRadius;
-        result.Y       += canvasRadius;
+        result.X += canvasRadius;
+        result.Y += canvasRadius;
 
         return result;
     }
 
-    SKPoint LimitToLRadius( SKPoint point, float canvasRadius )
+    SKPoint LimitToLRadius(SKPoint point, float canvasRadius)
     {
         var polar       = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
-        polar.Radius    = LRadius( canvasRadius );
+        polar.Radius = LRadius(canvasRadius);
         var result      = FromPolar(polar);
 
-        result.X       += canvasRadius;
-        result.Y       += canvasRadius;
+        result.X += canvasRadius;
+        result.Y += canvasRadius;
 
         return result;
     }
 
-    static PolarPoint ToPolar( SKPoint point )
+    static PolarPoint ToPolar(SKPoint point)
     {
         var radius    = (float)Math.Sqrt((point.X * point.X) + (point.Y * point.Y));
         var angle     = (float)Math.Atan2(point.Y, point.X);
 
-        return new PolarPoint( radius, angle );
+        return new PolarPoint(radius, angle);
     }
 
-    static SKPoint FromPolar( PolarPoint point )
+    static SKPoint FromPolar(PolarPoint point)
     {
         var x     = (float)(point.Radius * Math.Cos(point.Angle));
         var y     = (float)(point.Radius * Math.Sin(point.Angle));
 
-        return new SKPoint( x, y );
+        return new SKPoint(x, y);
     }
 
     // Small margin so the picker indicator (outer stroke + antialiasing)
     // does not get clipped at the canvas edge.
     const float PickerEdgeMargin = 3F;
 
-    float HsRadius( float canvasRadius )
-       => ! ShowLuminosityRing ? canvasRadius - GetIndicatorRadiusPixels() - PickerEdgeMargin
-                                : canvasRadius - ( 3 * GetIndicatorRadiusPixels() ) - 2;
+    float HsRadius(float canvasRadius)
+       => !ShowLuminosityRing ? canvasRadius - GetIndicatorRadiusPixels() - PickerEdgeMargin
+                                : canvasRadius - (3 * GetIndicatorRadiusPixels()) - 2;
 
-    float LRadius( float canvasRadius )
+    float LRadius(float canvasRadius)
        => canvasRadius - GetIndicatorRadiusPixels() - PickerEdgeMargin;
 }

--- a/ColorPicker/Controls/ColorTriangle.cs
+++ b/ColorPicker/Controls/ColorTriangle.cs
@@ -6,56 +6,56 @@ public class ColorTriangle : ColorPickerBase
     readonly AlphaSlider        _alphaSlider    = new();
 
     public static readonly BindableProperty ShowAlphaSliderProperty
-                         = BindableProperty.Create( nameof(ShowAlphaSlider),
+                         = BindableProperty.Create(nameof(ShowAlphaSlider),
                                                     typeof(bool),
                                                     typeof(ColorTriangle),
                                                     false,
-                                                    propertyChanged: HandleShowAlphaSlider );
+                                                    propertyChanged: HandleShowAlphaSlider);
 
     public static readonly BindableProperty VerticalProperty
-                         = BindableProperty.Create( nameof(Vertical),
+                         = BindableProperty.Create(nameof(Vertical),
                                                     typeof(bool),
                                                     typeof(ColorTriangle),
                                                     false,
-                                                    propertyChanged: HandleVertical );
+                                                    propertyChanged: HandleVertical);
 
     public static readonly BindableProperty RotateTriangleByHueProperty
-                         = BindableProperty.Create( nameof(RotateTriangleByHue),
+                         = BindableProperty.Create(nameof(RotateTriangleByHue),
                                                     typeof(bool),
                                                     typeof(ColorTriangle),
                                                     true,
-                                                    propertyChanged: HandleRotateTriangleByHue );
+                                                    propertyChanged: HandleRotateTriangleByHue);
 
     public static readonly BindableProperty CanvasBackgroundColorProperty
-                         = BindableProperty.Create( nameof(CanvasBackgroundColor),
+                         = BindableProperty.Create(nameof(CanvasBackgroundColor),
                                                     typeof(Color),
                                                     typeof(ColorTriangle),
                                                     Colors.Transparent,
-                                                    propertyChanged: HandleCanvasBackgroundColor );
+                                                    propertyChanged: HandleCanvasBackgroundColor);
 
     public static readonly BindableProperty IndicatorRadiusScaleProperty
-                         = BindableProperty.Create( nameof(IndicatorRadiusScale),
+                         = BindableProperty.Create(nameof(IndicatorRadiusScale),
                                                     typeof(float),
                                                     typeof(ColorTriangle),
                                                     0.035F,
-                                                    propertyChanged: HandleIndicatorRadiusScale );
+                                                    propertyChanged: HandleIndicatorRadiusScale);
 
     public bool ShowAlphaSlider
     {
-        get => (bool)GetValue( ShowAlphaSliderProperty );
-        set => SetValue( ShowAlphaSliderProperty, value );
+        get => (bool)GetValue(ShowAlphaSliderProperty);
+        set => SetValue(ShowAlphaSliderProperty, value);
     }
-    static void HandleShowAlphaSlider( BindableObject bindable, object oldValue, object newValue )
-            => ( (ColorTriangle)bindable ).UpdateAlphaSlider( (bool)newValue );
+    static void HandleShowAlphaSlider(BindableObject bindable, object oldValue, object newValue)
+            => ((ColorTriangle)bindable).UpdateAlphaSlider((bool)newValue);
 
     public bool Vertical
     {
-        get => (bool)GetValue( VerticalProperty );
-        set => SetValue( VerticalProperty, value );
+        get => (bool)GetValue(VerticalProperty);
+        set => SetValue(VerticalProperty, value);
     }
-    static void HandleVertical( BindableObject bindable, object oldValue, object newValue )
+    static void HandleVertical(BindableObject bindable, object oldValue, object newValue)
     {
-        if ( newValue != oldValue )
+        if (newValue != oldValue)
         {
             var triangle = (ColorTriangle)bindable;
             triangle._alphaSlider.Vertical = (bool)newValue;
@@ -65,41 +65,41 @@ public class ColorTriangle : ColorPickerBase
 
     public bool RotateTriangleByHue
     {
-        get => (bool)GetValue( RotateTriangleByHueProperty );
-        set => SetValue( RotateTriangleByHueProperty, value );
+        get => (bool)GetValue(RotateTriangleByHueProperty);
+        set => SetValue(RotateTriangleByHueProperty, value);
     }
-    static void HandleRotateTriangleByHue( BindableObject bindable, object oldValue, object newValue )
+    static void HandleRotateTriangleByHue(BindableObject bindable, object oldValue, object newValue)
     {
-        if ( newValue != oldValue )
-            ( (ColorTriangle)bindable )._area.RotateTriangleByHue = (bool)newValue;
+        if (newValue != oldValue)
+            ((ColorTriangle)bindable)._area.RotateTriangleByHue = (bool)newValue;
     }
 
     public Color CanvasBackgroundColor
     {
-        get => (Color)GetValue( CanvasBackgroundColorProperty );
-        set => SetValue( CanvasBackgroundColorProperty, value );
+        get => (Color)GetValue(CanvasBackgroundColorProperty);
+        set => SetValue(CanvasBackgroundColorProperty, value);
     }
-    static void HandleCanvasBackgroundColor( BindableObject bindable, object oldValue, object newValue )
+    static void HandleCanvasBackgroundColor(BindableObject bindable, object oldValue, object newValue)
     {
-        if ( newValue != oldValue )
-            ( (ColorTriangle)bindable )._area.CanvasBackgroundColor = (Color)newValue;
+        if (newValue != oldValue)
+            ((ColorTriangle)bindable)._area.CanvasBackgroundColor = (Color)newValue;
     }
 
     public float IndicatorRadiusScale
     {
-        get => (float)GetValue( IndicatorRadiusScaleProperty );
-        set => SetValue( IndicatorRadiusScaleProperty, value );
+        get => (float)GetValue(IndicatorRadiusScaleProperty);
+        set => SetValue(IndicatorRadiusScaleProperty, value);
     }
-    static void HandleIndicatorRadiusScale( BindableObject bindable, object oldValue, object newValue )
+    static void HandleIndicatorRadiusScale(BindableObject bindable, object oldValue, object newValue)
     {
-        if ( newValue != oldValue )
+        if (newValue != oldValue)
         {
             // Only propagate to the inner triangle area. The embedded alpha
             // slider uses SliderStack's auto-fill behavior (its own
             // IndicatorRadiusScale = 0): its picker radius is derived from
             // the slim strip we allot it in ArrangeLayoutChildren, mirroring
             // the pattern used by ColorWheel.
-            ( (ColorTriangle)bindable )._area.IndicatorRadiusScale = (float)newValue;
+            ((ColorTriangle)bindable)._area.IndicatorRadiusScale = (float)newValue;
         }
     }
 
@@ -111,28 +111,28 @@ public class ColorTriangle : ColorPickerBase
         _area.AttachedColorPicker = this;
 
         HorizontalOptions = LayoutOptions.Center;
-        VerticalOptions   = LayoutOptions.Center;
+        VerticalOptions = LayoutOptions.Center;
 
-        Children.Add( _area );
+        Children.Add(_area);
 
         _alphaSlider.AttachedColorPicker = this;
 
-        UpdateAlphaSlider( ShowAlphaSlider );
+        UpdateAlphaSlider(ShowAlphaSlider);
     }
 
-    protected override void OnSelectedColorChanging( Color color ) { }
+    protected override void OnSelectedColorChanging(Color color) { }
 
-    protected override Size MeasureOverride( double widthConstraint, double heightConstraint )
+    protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
     {
-        if ( WidthRequest >= 0 )
-            widthConstraint = Math.Min( widthConstraint, WidthRequest );
-        if ( HeightRequest >= 0 )
-            heightConstraint = Math.Min( heightConstraint, HeightRequest );
+        if (WidthRequest >= 0)
+            widthConstraint = Math.Min(widthConstraint, WidthRequest);
+        if (HeightRequest >= 0)
+            heightConstraint = Math.Min(heightConstraint, HeightRequest);
 
-        if ( double.IsPositiveInfinity( widthConstraint ) &&
-             double.IsPositiveInfinity( heightConstraint ) )
+        if (double.IsPositiveInfinity(widthConstraint) &&
+             double.IsPositiveInfinity(heightConstraint))
         {
-            widthConstraint  = 200;
+            widthConstraint = 200;
             heightConstraint = 200;
         }
 
@@ -143,23 +143,23 @@ public class ColorTriangle : ColorPickerBase
         double totalWidth;
         double totalHeight;
 
-        if ( Vertical )
+        if (Vertical)
         {
-            triangleSize = Math.Min( heightConstraint, ( 1.0 - sliderFraction ) * widthConstraint );
-            totalHeight  = triangleSize;
-            totalWidth   = sliderCount > 0 ? triangleSize / ( 1.0 - sliderFraction ) : triangleSize;
+            triangleSize = Math.Min(heightConstraint, (1.0 - sliderFraction) * widthConstraint);
+            totalHeight = triangleSize;
+            totalWidth = sliderCount > 0 ? triangleSize / (1.0 - sliderFraction) : triangleSize;
         }
         else
         {
-            triangleSize = Math.Min( widthConstraint, ( 1.0 - sliderFraction ) * heightConstraint );
-            totalWidth   = triangleSize;
-            totalHeight  = sliderCount > 0 ? triangleSize / ( 1.0 - sliderFraction ) : triangleSize;
+            triangleSize = Math.Min(widthConstraint, (1.0 - sliderFraction) * heightConstraint);
+            totalWidth = triangleSize;
+            totalHeight = sliderCount > 0 ? triangleSize / (1.0 - sliderFraction) : triangleSize;
         }
 
-        return new Size( totalWidth, totalHeight );
+        return new Size(totalWidth, totalHeight);
     }
 
-    protected override Size ArrangeLayoutChildren( Rect bounds )
+    protected override Size ArrangeLayoutChildren(Rect bounds)
     {
         var width  = bounds.Width;
         var height = bounds.Height;
@@ -170,53 +170,53 @@ public class ColorTriangle : ColorPickerBase
         double triangleSize;
         double sliderThickness;
 
-        if ( Vertical )
+        if (Vertical)
         {
-            triangleSize    = Math.Min( height,
-                                        sliderCount > 0 ? ( 1.0 - sliderFraction ) * width : width );
+            triangleSize = Math.Min(height,
+                                        sliderCount > 0 ? (1.0 - sliderFraction) * width : width);
             sliderThickness = sliderCount > 0
-                            ? ( sliderFraction * triangleSize ) / ( ( 1.0 - sliderFraction ) * sliderCount )
+                            ? (sliderFraction * triangleSize) / ((1.0 - sliderFraction) * sliderCount)
                             : 0;
         }
         else
         {
-            triangleSize    = Math.Min( width,
-                                        sliderCount > 0 ? ( 1.0 - sliderFraction ) * height : height );
+            triangleSize = Math.Min(width,
+                                        sliderCount > 0 ? (1.0 - sliderFraction) * height : height);
             sliderThickness = sliderCount > 0
-                            ? ( sliderFraction * triangleSize ) / ( ( 1.0 - sliderFraction ) * sliderCount )
+                            ? (sliderFraction * triangleSize) / ((1.0 - sliderFraction) * sliderCount)
                             : 0;
         }
 
-        ( (IView)_area ).Measure( triangleSize, triangleSize );
-        ( (IView)_area ).Arrange( new Rect( 0, 0, triangleSize, triangleSize ) );
+        ((IView)_area).Measure(triangleSize, triangleSize);
+        ((IView)_area).Arrange(new Rect(0, 0, triangleSize, triangleSize));
 
-        if ( ShowAlphaSlider )
+        if (ShowAlphaSlider)
         {
-            if ( Vertical )
+            if (Vertical)
             {
-                ( (IView)_alphaSlider ).Measure( sliderThickness, triangleSize );
-                ( (IView)_alphaSlider ).Arrange( new Rect( triangleSize, 0, sliderThickness, triangleSize ) );
+                ((IView)_alphaSlider).Measure(sliderThickness, triangleSize);
+                ((IView)_alphaSlider).Arrange(new Rect(triangleSize, 0, sliderThickness, triangleSize));
             }
             else
             {
-                ( (IView)_alphaSlider ).Measure( triangleSize, sliderThickness );
-                ( (IView)_alphaSlider ).Arrange( new Rect( 0, triangleSize, triangleSize, sliderThickness ) );
+                ((IView)_alphaSlider).Measure(triangleSize, sliderThickness);
+                ((IView)_alphaSlider).Arrange(new Rect(0, triangleSize, triangleSize, sliderThickness));
             }
         }
 
         return bounds.Size;
     }
 
-    void UpdateAlphaSlider( bool show )
+    void UpdateAlphaSlider(bool show)
     {
-        if ( show )
+        if (show)
         {
-            if ( !Children.Contains( _alphaSlider ) )
-                Children.Add( _alphaSlider );
+            if (!Children.Contains(_alphaSlider))
+                Children.Add(_alphaSlider);
         }
         else
         {
-            Children.Remove( _alphaSlider );
+            Children.Remove(_alphaSlider);
         }
     }
 }

--- a/ColorPicker/Controls/ColorTriangleArea.cs
+++ b/ColorPicker/Controls/ColorTriangleArea.cs
@@ -18,14 +18,14 @@ public class ColorTriangleArea : SkiaPickerBase
                                                     typeof(Color),
                                                     typeof(ColorTriangleArea),
                                                     Colors.Transparent,
-                                                    propertyChanged: HandleCanvasBackgroundColorChanged );
+                                                    propertyChanged: HandleCanvasBackgroundColorChanged);
     public Color CanvasBackgroundColor
     {
-        get => (Color)GetValue( CanvasBackgroundColorProperty );
-        set => SetValue( CanvasBackgroundColorProperty, value );
+        get => (Color)GetValue(CanvasBackgroundColorProperty);
+        set => SetValue(CanvasBackgroundColorProperty, value);
     }
 
-    static void HandleCanvasBackgroundColorChanged( BindableObject bindable, object oldValue, object newValue )
+    static void HandleCanvasBackgroundColorChanged(BindableObject bindable, object oldValue, object newValue)
     {
         if (newValue != oldValue)
         {
@@ -38,14 +38,14 @@ public class ColorTriangleArea : SkiaPickerBase
                                                     typeof(bool),
                                                     typeof(ColorTriangleArea),
                                                     true,
-                                                    propertyChanged: HandleRotateTriangleByHueSet );
+                                                    propertyChanged: HandleRotateTriangleByHueSet);
     public bool RotateTriangleByHue
     {
-        get => (bool)GetValue( RotateTriangleByHueProperty );
-        set => SetValue( RotateTriangleByHueProperty, value );
+        get => (bool)GetValue(RotateTriangleByHueProperty);
+        set => SetValue(RotateTriangleByHueProperty, value);
     }
 
-    static void HandleRotateTriangleByHueSet( BindableObject bindable, object oldValue, object newValue )
+    static void HandleRotateTriangleByHueSet(BindableObject bindable, object oldValue, object newValue)
     {
         if (newValue != oldValue)
         {
@@ -59,18 +59,18 @@ public class ColorTriangleArea : SkiaPickerBase
     public ColorTriangleArea() : base()
     {
         HorizontalOptions = LayoutOptions.Center;
-        VerticalOptions   = LayoutOptions.Center;
+        VerticalOptions = LayoutOptions.Center;
         IndicatorRadiusScale = 0.035F;
         for (var i = 128; i >= -127; i--)
         {
-            _sweepGradientColors[ 255 - (i + 127) ] = Color.FromHsla( (i < 0 ? 255 + i : i) / 255D, 1, 0.5 ).ToSKColor();
+            _sweepGradientColors[255 - (i + 127)] = Color.FromHsla((i < 0 ? 255 + i : i) / 255D, 1, 0.5).ToSKColor();
         }
     }
 
-    public override float GetIndicatorRadiusPixels( SKSize canvasSize ) => GetSize( canvasSize ) * IndicatorRadiusScale;
-    public override float GetIndicatorRadiusPixels() => GetIndicatorRadiusPixels( GetCanvasSize() );
+    public override float GetIndicatorRadiusPixels(SKSize canvasSize) => GetSize(canvasSize) * IndicatorRadiusScale;
+    public override float GetIndicatorRadiusPixels() => GetIndicatorRadiusPixels(GetCanvasSize());
 
-    protected override void OnTouchActionPressed( TouchActionEventArgs args )
+    protected override void OnTouchActionPressed(TouchActionEventArgs args)
     {
         var canvasRadius = GetSize() / 2F;
         var (offX, offY) = GetDrawingOffset();
@@ -78,21 +78,21 @@ public class ColorTriangleArea : SkiaPickerBase
         point.X -= offX;
         point.Y -= offY;
 
-        if (_locationSvProgressId is null && IsInSvArea( point, canvasRadius ))
+        if (_locationSvProgressId is null && IsInSvArea(point, canvasRadius))
         {
             _locationSvProgressId = args.Id;
-            _locationSv = LimitToSvTriangle( point, canvasRadius );
-            UpdateColors( canvasRadius );
+            _locationSv = LimitToSvTriangle(point, canvasRadius);
+            UpdateColors(canvasRadius);
         }
-        else if (_locationHProgressId is null && IsInHArea( point, canvasRadius ))
+        else if (_locationHProgressId is null && IsInHArea(point, canvasRadius))
         {
             _locationHProgressId = args.Id;
-            LimitToHRadius( point, canvasRadius );
-            UpdateColors( canvasRadius );
+            LimitToHRadius(point, canvasRadius);
+            UpdateColors(canvasRadius);
         }
     }
 
-    protected override void OnTouchActionMoved( TouchActionEventArgs args )
+    protected override void OnTouchActionMoved(TouchActionEventArgs args)
     {
         var canvasRadius = GetSize() / 2F;
         var (offX, offY) = GetDrawingOffset();
@@ -102,17 +102,17 @@ public class ColorTriangleArea : SkiaPickerBase
 
         if (_locationSvProgressId == args.Id)
         {
-            _locationSv = LimitToSvTriangle( point, canvasRadius );
-            UpdateColors( canvasRadius );
+            _locationSv = LimitToSvTriangle(point, canvasRadius);
+            UpdateColors(canvasRadius);
         }
         else if (_locationHProgressId == args.Id)
         {
-            LimitToHRadius( point, canvasRadius );
-            UpdateColors( canvasRadius );
+            LimitToHRadius(point, canvasRadius);
+            UpdateColors(canvasRadius);
         }
     }
 
-    protected override void OnTouchActionReleased( TouchActionEventArgs args )
+    protected override void OnTouchActionReleased(TouchActionEventArgs args)
     {
         var canvasRadius = GetSize() / 2F;
         var (offX, offY) = GetDrawingOffset();
@@ -123,18 +123,18 @@ public class ColorTriangleArea : SkiaPickerBase
         if (_locationSvProgressId == args.Id)
         {
             _locationSvProgressId = null;
-            _locationSv = LimitToSvTriangle( point, canvasRadius );
-            UpdateColors( canvasRadius );
+            _locationSv = LimitToSvTriangle(point, canvasRadius);
+            UpdateColors(canvasRadius);
         }
         else if (_locationHProgressId == args.Id)
         {
             _locationHProgressId = null;
-            LimitToHRadius( point, canvasRadius );
-            UpdateColors( canvasRadius );
+            LimitToHRadius(point, canvasRadius);
+            UpdateColors(canvasRadius);
         }
     }
 
-    protected override void OnTouchActionCancelled( TouchActionEventArgs args )
+    protected override void OnTouchActionCancelled(TouchActionEventArgs args)
     {
         if (_locationSvProgressId == args.Id)
             _locationSvProgressId = null;
@@ -142,32 +142,32 @@ public class ColorTriangleArea : SkiaPickerBase
             _locationHProgressId = null;
     }
 
-    protected override void OnPaintSurface( SKCanvas canvas, int width, int height )
+    protected override void OnPaintSurface(SKCanvas canvas, int width, int height)
     {
         var canvasRadius = GetSize() / 2F;
         var (offX, offY) = GetDrawingOffset();
 
-        UpdateLocations( SelectedColor, canvasRadius );
+        UpdateLocations(SelectedColor, canvasRadius);
         canvas.Clear();
 
         canvas.Save();
-        canvas.Translate( offX, offY );
+        canvas.Translate(offX, offY);
 
-        PaintBackground( canvas, canvasRadius );
-        PaintHGradient( canvas, canvasRadius );
+        PaintBackground(canvas, canvasRadius);
+        PaintHGradient(canvas, canvasRadius);
 
         if (RotateTriangleByHue)
-            PaintLinePicker( canvas );
+            PaintLinePicker(canvas);
         else
-            PaintIndicator( canvas, _locationMiddleH );
+            PaintIndicator(canvas, _locationMiddleH);
 
-        PaintSvTriangle( canvas, canvasRadius );
-        PaintIndicator( canvas, _locationSv );
+        PaintSvTriangle(canvas, canvasRadius);
+        PaintIndicator(canvas, _locationSv);
 
         canvas.Restore();
     }
 
-    protected override void OnSelectedColorChanging( Color color )
+    protected override void OnSelectedColorChanging(Color color)
     {
         if (color.GetSaturation() > 0.00390625D)
         {
@@ -182,49 +182,49 @@ public class ColorTriangleArea : SkiaPickerBase
         InvalidateSurface();
     }
 
-    protected override SizeRequest GetMeasure( double widthConstraint, double heightConstraint )
+    protected override SizeRequest GetMeasure(double widthConstraint, double heightConstraint)
     {
-        if (double.IsPositiveInfinity( widthConstraint ) &&
-             double.IsPositiveInfinity( heightConstraint ))
+        if (double.IsPositiveInfinity(widthConstraint) &&
+             double.IsPositiveInfinity(heightConstraint))
         {
             widthConstraint = 200;
             heightConstraint = 200;
         }
 
-        var size = Math.Min( widthConstraint, heightConstraint );
+        var size = Math.Min(widthConstraint, heightConstraint);
 
-        return new SizeRequest( new Size( size, size ) );
+        return new SizeRequest(new Size(size, size));
     }
 
-    protected override float GetSize( SKSize canvasSize ) => Math.Min( canvasSize.Width, canvasSize.Height );
-    protected override float GetSize() => GetSize( GetCanvasSize() );
+    protected override float GetSize(SKSize canvasSize) => Math.Min(canvasSize.Width, canvasSize.Height);
+    protected override float GetSize() => GetSize(GetCanvasSize());
 
     (float offsetX, float offsetY) GetDrawingOffset()
     {
         var canvas = GetCanvasSize();
-        var size   = Math.Min( canvas.Width, canvas.Height );
-        return ( ( canvas.Width - size ) / 2F, ( canvas.Height - size ) / 2F );
+        var size   = Math.Min(canvas.Width, canvas.Height);
+        return ((canvas.Width - size) / 2F, (canvas.Height - size) / 2F);
     }
 
-    void UpdateLocations( Color color, float canvasRadius )
+    void UpdateLocations(Color color, float canvasRadius)
     {
-        ColorToHsv( color, out _, out var saturation, out var value );
+        ColorToHsv(color, out _, out var saturation, out var value);
 
-        var luminosityX = -(float)( (2 * _triangleSide * saturation) - _triangleSide );
+        var luminosityX = -(float)((2 * _triangleSide * saturation) - _triangleSide);
         var luminosityY = _triangleHeight;
 
         var polarValue = ToPolar(new SKPoint(luminosityX, luminosityY));
         polarValue.Radius *= (float)value;
 
-        _locationSv = FromPolar( polarValue );
+        _locationSv = FromPolar(polarValue);
         _locationSv.X = -_locationSv.X;
         _locationSv.Y -= 1;
-        _locationSv.X *= SvRadius( canvasRadius );
-        _locationSv.Y *= SvRadius( canvasRadius );
+        _locationSv.X *= SvRadius(canvasRadius);
+        _locationSv.Y *= SvRadius(canvasRadius);
 
-        polarValue = ToPolar( new SKPoint( _locationSv.X, _locationSv.Y ) );
+        polarValue = ToPolar(new SKPoint(_locationSv.X, _locationSv.Y));
         polarValue.Angle -= (float)(2 * Math.PI / 3);
-        _locationSv = FromPolar( polarValue );
+        _locationSv = FromPolar(polarValue);
 
         _locationSv.X += canvasRadius;
         _locationSv.Y += canvasRadius;
@@ -232,25 +232,25 @@ public class ColorTriangleArea : SkiaPickerBase
         if (RotateTriangleByHue)
         {
             var rotationHue = SKMatrix.CreateRotation(-(float)((2D * Math.PI * _lastHue) + (Math.PI / 2D)), canvasRadius, canvasRadius);
-            _locationSv = rotationHue.MapPoint( _locationSv );
+            _locationSv = rotationHue.MapPoint(_locationSv);
         }
 
         var angleH = _lastHue * Math.PI * 2;
 
-        _locationMiddleH = FromPolar( new PolarPoint( HRadius( canvasRadius ), (float)(Math.PI - angleH) ) );
+        _locationMiddleH = FromPolar(new PolarPoint(HRadius(canvasRadius), (float)(Math.PI - angleH)));
         _locationMiddleH.X += canvasRadius;
         _locationMiddleH.Y += canvasRadius;
 
-        _locationH1 = FromPolar( new PolarPoint( HRadius( canvasRadius ) + GetIndicatorRadiusPixels(), (float)(Math.PI - angleH) ) );
+        _locationH1 = FromPolar(new PolarPoint(HRadius(canvasRadius) + GetIndicatorRadiusPixels(), (float)(Math.PI - angleH)));
         _locationH1.X += canvasRadius;
         _locationH1.Y += canvasRadius;
 
-        _locationH2 = FromPolar( new PolarPoint( HRadius( canvasRadius ) - GetIndicatorRadiusPixels(), (float)(Math.PI - angleH) ) );
+        _locationH2 = FromPolar(new PolarPoint(HRadius(canvasRadius) - GetIndicatorRadiusPixels(), (float)(Math.PI - angleH)));
         _locationH2.X += canvasRadius;
         _locationH2.Y += canvasRadius;
     }
 
-    void UpdateColors( float canvasRadius )
+    void UpdateColors(float canvasRadius)
     {
         var svPoint = ToSvCoordinates(_locationSv, canvasRadius);
         var hPoint = ToHCoordinates(_locationH1, canvasRadius);
@@ -258,25 +258,25 @@ public class ColorTriangleArea : SkiaPickerBase
 
         if (_zeroSL && (newColor.GetSaturation() > 0))
         {
-            newColor = Color.FromHsla( _lastHue, newColor.GetSaturation(), newColor.GetLuminosity(), newColor.Alpha );
+            newColor = Color.FromHsla(_lastHue, newColor.GetSaturation(), newColor.GetLuminosity(), newColor.Alpha);
         }
 
         SelectedColor = newColor;
     }
 
-    bool IsInSvArea( SKPoint point, float canvasRadius )
+    bool IsInSvArea(SKPoint point, float canvasRadius)
     {
         var polar = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
-        return polar.Radius <= SvRadius( canvasRadius );
+        return polar.Radius <= SvRadius(canvasRadius);
     }
 
-    bool IsInHArea( SKPoint point, float canvasRadius )
+    bool IsInHArea(SKPoint point, float canvasRadius)
     {
         var polar = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
-        return polar.Radius <= HRadius( canvasRadius ) + GetIndicatorRadiusPixels() && polar.Radius >= HRadius( canvasRadius ) - GetIndicatorRadiusPixels();
+        return polar.Radius <= HRadius(canvasRadius) + GetIndicatorRadiusPixels() && polar.Radius >= HRadius(canvasRadius) - GetIndicatorRadiusPixels();
     }
 
-    void PaintBackground( SKCanvas canvas, float canvasRadius )
+    void PaintBackground(SKCanvas canvas, float canvasRadius)
     {
         var center = new SKPoint(canvasRadius, canvasRadius);
         var paint = new SKPaint
@@ -285,10 +285,10 @@ public class ColorTriangleArea : SkiaPickerBase
             Color = CanvasBackgroundColor.ToSKColor()
         };
 
-        canvas.DrawCircle( center, canvasRadius, paint );
+        canvas.DrawCircle(center, canvasRadius, paint);
     }
 
-    void PaintHGradient( SKCanvas canvas, float canvasRadius )
+    void PaintHGradient(SKCanvas canvas, float canvasRadius)
     {
         var center = new SKPoint(canvasRadius, canvasRadius);
         var shader = SKShader.CreateSweepGradient(center, _sweepGradientColors, null);
@@ -300,22 +300,22 @@ public class ColorTriangleArea : SkiaPickerBase
             Style = SKPaintStyle.Stroke,
             StrokeWidth = GetIndicatorRadiusPixels() * 2
         };
-        canvas.DrawCircle( center, HRadius( canvasRadius ), paint );
+        canvas.DrawCircle(center, HRadius(canvasRadius), paint);
     }
 
-    void PaintSvTriangle( SKCanvas canvas, float canvasRadius )
+    void PaintSvTriangle(SKCanvas canvas, float canvasRadius)
     {
         canvas.Save();
 
-        var rotationHue = SKMatrix.CreateRotation(-(float)( (2D * Math.PI * _lastHue) + (Math.PI / 2D) ),
+        var rotationHue = SKMatrix.CreateRotation(-(float)((2D * Math.PI * _lastHue) + (Math.PI / 2D)),
                                                    canvasRadius, canvasRadius);
 
-        if ( RotateTriangleByHue )
+        if (RotateTriangleByHue)
         {
-            canvas.Concat( ref rotationHue );
+            canvas.Concat(ref rotationHue);
         }
 
-        var point1 = new SKPoint( canvasRadius, canvasRadius - SvRadius(canvasRadius) );
+        var point1 = new SKPoint(canvasRadius, canvasRadius - SvRadius(canvasRadius));
         var point2 = new SKPoint(canvasRadius + (_triangleSide * SvRadius(canvasRadius))
                 , canvasRadius + (_triangleVerticalOffset * SvRadius(canvasRadius)));
 
@@ -324,17 +324,17 @@ public class ColorTriangleArea : SkiaPickerBase
 
         using (var pathTriangle = new SKPath())
         {
-            pathTriangle.MoveTo( point1 );
-            pathTriangle.LineTo( point2 );
-            pathTriangle.LineTo( point3 );
+            pathTriangle.MoveTo(point1);
+            pathTriangle.LineTo(point2);
+            pathTriangle.LineTo(point3);
 
-            canvas.ClipPath( pathTriangle, SKClipOperation.Intersect, true );
+            canvas.ClipPath(pathTriangle, SKClipOperation.Intersect, true);
         }
 
         canvas.Save();
 
         var gradientRotation = SKMatrix.CreateRotation(-(float)Math.PI / 3F, point3.X, point3.Y);
-        canvas.Concat( ref gradientRotation );
+        canvas.Concat(ref gradientRotation);
 
         var shader = SKShader.CreateSweepGradient(point3,
                                                    new SKColor[]
@@ -355,7 +355,7 @@ public class ColorTriangleArea : SkiaPickerBase
             Style       = SKPaintStyle.Fill
         };
 
-        canvas.DrawCircle( point3, SvRadius( canvasRadius ) * 2, paint );
+        canvas.DrawCircle(point3, SvRadius(canvasRadius) * 2, paint);
 
         canvas.Restore();
 
@@ -365,12 +365,12 @@ public class ColorTriangleArea : SkiaPickerBase
             SKColors.Transparent
         };
 
-        PaintGradient( canvas, canvasRadius, colors, point3 );
+        PaintGradient(canvas, canvasRadius, colors, point3);
 
         canvas.Restore();
     }
 
-    void PaintGradient( SKCanvas canvas, float canvasRadius, SKColor[] colors, SKPoint centerGradient )
+    void PaintGradient(SKCanvas canvas, float canvasRadius, SKColor[] colors, SKPoint centerGradient)
     {
         var center = new SKPoint(canvasRadius, canvasRadius);
         var polar = ToPolar(new SKPoint(center.X - centerGradient.X, center.Y - centerGradient.Y));
@@ -390,29 +390,29 @@ public class ColorTriangleArea : SkiaPickerBase
             Style       = SKPaintStyle.Fill
         };
 
-        canvas.DrawCircle( center, SvRadius( canvasRadius ), paint );
+        canvas.DrawCircle(center, SvRadius(canvasRadius), paint);
     }
 
-    SKPoint ToSvCoordinates( SKPoint point, float canvasRadius )
+    SKPoint ToSvCoordinates(SKPoint point, float canvasRadius)
     {
         var result = new SKPoint(point.X, point.Y);
 
         result.X -= canvasRadius;
         result.Y -= canvasRadius;
-        result.X /= SvRadius( canvasRadius );
-        result.Y /= SvRadius( canvasRadius );
+        result.X /= SvRadius(canvasRadius);
+        result.Y /= SvRadius(canvasRadius);
 
         return result;
     }
 
-    SKPoint ToHCoordinates( SKPoint point, float canvasRadius )
+    SKPoint ToHCoordinates(SKPoint point, float canvasRadius)
     {
         var result = new SKPoint(point.X, point.Y);
 
         result.X -= canvasRadius;
         result.Y -= canvasRadius;
-        result.X /= HRadius( canvasRadius );
-        result.Y /= HRadius( canvasRadius );
+        result.X /= HRadius(canvasRadius);
+        result.Y /= HRadius(canvasRadius);
 
         return result;
     }
@@ -421,12 +421,12 @@ public class ColorTriangleArea : SkiaPickerBase
     const float _triangleSide = 0.8660244F;
     const float _triangleVerticalOffset = 0.5000001F;
 
-    Color WheelPointToColor( SKPoint pointSV, SKPoint pointH )
+    Color WheelPointToColor(SKPoint pointSV, SKPoint pointH)
     {
         if (RotateTriangleByHue)
         {
             var rotationHue = SKMatrix.CreateRotation((float)((2D * Math.PI * _lastHue) + (Math.PI / 2D)));
-            pointSV = rotationHue.MapPoint( pointSV );
+            pointSV = rotationHue.MapPoint(pointSV);
         }
 
         var polarH = ToPolar(pointH);
@@ -440,7 +440,7 @@ public class ColorTriangleArea : SkiaPickerBase
         var x2 = x1 * 2;
         var y2 = 0F;
 
-        var vCurrent = ( (pointSV.X * (y2 - y1)) - (pointSV.Y * (x2 - x1)) + (x2 * y1) - (y2 * x1)) / Math.Sqrt(Math.Pow(y2 - y1, 2) + Math.Pow(x2 - x1, 2) );
+        var vCurrent = ((pointSV.X * (y2 - y1)) - (pointSV.Y * (x2 - x1)) + (x2 * y1) - (y2 * x1)) / Math.Sqrt(Math.Pow(y2 - y1, 2) + Math.Pow(x2 - x1, 2));
         var v = (y1 - vCurrent) / y1;
 
         var sMax = x2 - (vCurrent / Math.Sin(Math.PI / 3));
@@ -453,10 +453,10 @@ public class ColorTriangleArea : SkiaPickerBase
         return result;
     }
 
-    SKPoint LimitToSvTriangle( SKPoint point, float canvasRadius )
+    SKPoint LimitToSvTriangle(SKPoint point, float canvasRadius)
     {
         var polar = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
-        polar.Radius = polar.Radius < SvRadius( canvasRadius ) ? polar.Radius : SvRadius( canvasRadius );
+        polar.Radius = polar.Radius < SvRadius(canvasRadius) ? polar.Radius : SvRadius(canvasRadius);
 
         var result = FromPolar(polar);
         result.X += canvasRadius;
@@ -464,16 +464,16 @@ public class ColorTriangleArea : SkiaPickerBase
         return result;
     }
 
-    void LimitToHRadius( SKPoint point, float canvasRadius )
+    void LimitToHRadius(SKPoint point, float canvasRadius)
     {
         var point1 = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
-        point1.Radius = HRadius( canvasRadius ) + GetIndicatorRadiusPixels();
+        point1.Radius = HRadius(canvasRadius) + GetIndicatorRadiusPixels();
 
         var point2 = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
-        point1.Radius = HRadius( canvasRadius ) - GetIndicatorRadiusPixels();
+        point1.Radius = HRadius(canvasRadius) - GetIndicatorRadiusPixels();
 
-        _locationH1 = FromPolar( point1 );
-        _locationH2 = FromPolar( point2 );
+        _locationH1 = FromPolar(point1);
+        _locationH2 = FromPolar(point2);
 
         _locationH1.X += canvasRadius;
         _locationH1.Y += canvasRadius;
@@ -481,24 +481,24 @@ public class ColorTriangleArea : SkiaPickerBase
         _locationH2.Y += canvasRadius;
     }
 
-    static PolarPoint ToPolar( SKPoint point )
+    static PolarPoint ToPolar(SKPoint point)
     {
         var radius = (float)Math.Sqrt((point.X * point.X) + (point.Y * point.Y));
         var angle = (float)Math.Atan2(point.Y, point.X);
-        return new PolarPoint( radius, angle );
+        return new PolarPoint(radius, angle);
     }
 
-    static SKPoint FromPolar( PolarPoint point )
+    static SKPoint FromPolar(PolarPoint point)
     {
         var x = (float)(point.Radius * Math.Cos(point.Angle));
         var y = (float)(point.Radius * Math.Sin(point.Angle));
-        return new SKPoint( x, y );
+        return new SKPoint(x, y);
     }
 
-    float SvRadius( float canvasRadius ) => canvasRadius - (2 * GetIndicatorRadiusPixels()) - 2;
-    float HRadius( float canvasRadius ) => canvasRadius - GetIndicatorRadiusPixels();
+    float SvRadius(float canvasRadius) => canvasRadius - (2 * GetIndicatorRadiusPixels()) - 2;
+    float HRadius(float canvasRadius) => canvasRadius - GetIndicatorRadiusPixels();
 
-    void PaintLinePicker( SKCanvas canvas )
+    void PaintLinePicker(SKCanvas canvas)
     {
         var paint = new SKPaint
         {
@@ -510,13 +510,13 @@ public class ColorTriangleArea : SkiaPickerBase
         paint.StrokeWidth = 4;
 
         using var pathTriangle = new SKPath();
-        pathTriangle.MoveTo( _locationH1 );
-        pathTriangle.LineTo( _locationH2 );
+        pathTriangle.MoveTo(_locationH1);
+        pathTriangle.LineTo(_locationH2);
 
-        canvas.DrawPath( pathTriangle, paint );
+        canvas.DrawPath(pathTriangle, paint);
     }
 
-    public static void ColorToHsv( Color color, out double hue, out double saturation, out double value )
+    public static void ColorToHsv(Color color, out double hue, out double saturation, out double value)
     {
         var rgb = new Rgb { R = Math.Round(color.Red * 255F), G = Math.Round(color.Green * 255F), B = Math.Round(color.Blue * 255F) };
         var hsv = rgb.To<Hsv>();
@@ -526,9 +526,9 @@ public class ColorTriangleArea : SkiaPickerBase
         value = hsv.V;
     }
 
-    public static Color ColorFromHsv( double hue, double saturation, double value, double a )
+    public static Color ColorFromHsv(double hue, double saturation, double value, double a)
     {
         var result = Color.FromHsv((float)hue, (float)saturation, (float)value);
-        return new Color( result.Red, result.Green, result.Blue, (float)a );
+        return new Color(result.Red, result.Green, result.Blue, (float)a);
     }
 }

--- a/ColorPicker/Controls/ColorWheel.cs
+++ b/ColorPicker/Controls/ColorWheel.cs
@@ -9,94 +9,94 @@ public class ColorWheel : ColorPickerBase
     protected const double LuminositySliderRowHeight    = 12;
     protected const double AlphaSliderRowHeight         = 12;
 
-    public static readonly BindableProperty ShowLuminosityRingProperty 
-                         = BindableProperty.Create( nameof(ShowLuminosityRing),
+    public static readonly BindableProperty ShowLuminosityRingProperty
+                         = BindableProperty.Create(nameof(ShowLuminosityRing),
                                                     typeof(bool),
                                                     typeof(ColorWheel),
                                                     true,
-                                                    propertyChanged: HandleShowLuminosity );
+                                                    propertyChanged: HandleShowLuminosity);
 
-    public static readonly BindableProperty ShowLuminositySliderProperty 
-                         = BindableProperty.Create( nameof(ShowLuminositySlider),
+    public static readonly BindableProperty ShowLuminositySliderProperty
+                         = BindableProperty.Create(nameof(ShowLuminositySlider),
                                                     typeof(bool),
                                                     typeof(ColorWheel),
                                                     false,
-                                                    propertyChanged: HandleShowLuminositySlider );
+                                                    propertyChanged: HandleShowLuminositySlider);
 
-    public static readonly BindableProperty ShowAlphaSliderProperty 
-                         = BindableProperty.Create( nameof(ShowAlphaSlider),
+    public static readonly BindableProperty ShowAlphaSliderProperty
+                         = BindableProperty.Create(nameof(ShowAlphaSlider),
                                                     typeof(bool),
                                                     typeof(ColorWheel),
                                                     false,
-                                                    propertyChanged: HandleShowAlphaSlider );
+                                                    propertyChanged: HandleShowAlphaSlider);
 
-    public static readonly BindableProperty CanvasBackgroundColorProperty 
-                         = BindableProperty.Create( nameof(CanvasBackgroundColor),
+    public static readonly BindableProperty CanvasBackgroundColorProperty
+                         = BindableProperty.Create(nameof(CanvasBackgroundColor),
                                                     typeof(Color),
                                                     typeof(ColorWheel),
                                                     Colors.Transparent,
-                                                    propertyChanged: HandleCanvasBackgroundColor );
+                                                    propertyChanged: HandleCanvasBackgroundColor);
 
-    public static readonly BindableProperty IndicatorRadiusScaleProperty 
-                         = BindableProperty.Create( nameof(IndicatorRadiusScale),
+    public static readonly BindableProperty IndicatorRadiusScaleProperty
+                         = BindableProperty.Create(nameof(IndicatorRadiusScale),
                                                     typeof(float),
                                                     typeof(ColorWheel),
                                                     0.05F,
-                                                    propertyChanged: HandlePickerRadiusScale );
+                                                    propertyChanged: HandlePickerRadiusScale);
 
-    public static readonly BindableProperty VerticalProperty 
-                         = BindableProperty.Create( nameof(Vertical),
+    public static readonly BindableProperty VerticalProperty
+                         = BindableProperty.Create(nameof(Vertical),
                                                     typeof(bool),
                                                     typeof(ColorWheel),
                                                     false,
-                                                    propertyChanged: HandleVertical );
+                                                    propertyChanged: HandleVertical);
 
     public bool ShowLuminosityRing
     {
-        get => (bool)GetValue( ShowLuminosityRingProperty );
-        set => SetValue( ShowLuminosityRingProperty, value );
+        get => (bool)GetValue(ShowLuminosityRingProperty);
+        set => SetValue(ShowLuminosityRingProperty, value);
     }
-    static void HandleShowLuminosity( BindableObject bindable, object oldValue, object newValue )
-            => ( (ColorWheel)bindable )._disc.ShowLuminosityRing = (bool)newValue;
+    static void HandleShowLuminosity(BindableObject bindable, object oldValue, object newValue)
+            => ((ColorWheel)bindable)._disc.ShowLuminosityRing = (bool)newValue;
 
 
     public bool ShowLuminositySlider
     {
-        get => (bool)GetValue( ShowLuminositySliderProperty );
-        set => SetValue( ShowLuminositySliderProperty, value );
+        get => (bool)GetValue(ShowLuminositySliderProperty);
+        set => SetValue(ShowLuminositySliderProperty, value);
     }
-    static void HandleShowLuminositySlider( BindableObject bindable, object oldValue, object newValue )
-            => ( (ColorWheel)bindable ).UpdateLuminositySlider( (bool)newValue );
+    static void HandleShowLuminositySlider(BindableObject bindable, object oldValue, object newValue)
+            => ((ColorWheel)bindable).UpdateLuminositySlider((bool)newValue);
 
 
     public bool ShowAlphaSlider
     {
-        get => (bool)GetValue( ShowAlphaSliderProperty );
-        set => SetValue( ShowAlphaSliderProperty, value );
+        get => (bool)GetValue(ShowAlphaSliderProperty);
+        set => SetValue(ShowAlphaSliderProperty, value);
     }
-    static void HandleShowAlphaSlider( BindableObject bindable, object oldValue, object newValue )
-            => ( (ColorWheel)bindable ).UpdateAlphaSlider( (bool)newValue );
+    static void HandleShowAlphaSlider(BindableObject bindable, object oldValue, object newValue)
+            => ((ColorWheel)bindable).UpdateAlphaSlider((bool)newValue);
 
 
     public Color CanvasBackgroundColor
     {
-        get => (Color)GetValue( CanvasBackgroundColorProperty );
-        set => SetValue( CanvasBackgroundColorProperty, value );
+        get => (Color)GetValue(CanvasBackgroundColorProperty);
+        set => SetValue(CanvasBackgroundColorProperty, value);
     }
-    static void HandleCanvasBackgroundColor( BindableObject bindable, object oldValue, object newValue )
+    static void HandleCanvasBackgroundColor(BindableObject bindable, object oldValue, object newValue)
     {
-        if ( newValue != oldValue )
-            ( (ColorWheel)bindable )._disc.CanvasBackgroundColor = (Color)newValue;
+        if (newValue != oldValue)
+            ((ColorWheel)bindable)._disc.CanvasBackgroundColor = (Color)newValue;
     }
 
     public float IndicatorRadiusScale
     {
-        get => (float)GetValue( IndicatorRadiusScaleProperty );
-        set => SetValue( IndicatorRadiusScaleProperty, value );
+        get => (float)GetValue(IndicatorRadiusScaleProperty);
+        set => SetValue(IndicatorRadiusScaleProperty, value);
     }
-    static void HandlePickerRadiusScale( BindableObject bindable, object oldValue, object newValue )
+    static void HandlePickerRadiusScale(BindableObject bindable, object oldValue, object newValue)
     {
-        if ( newValue != oldValue )
+        if (newValue != oldValue)
         {
             // Only propagate to the disc/ring. The embedded sliders use
             // SliderStack's auto-fill behavior (IndicatorRadiusScale = 0): their
@@ -105,18 +105,18 @@ public class ColorWheel : ColorPickerBase
             // size visually consistent with the wheel's own picker. Forwarding
             // a non-zero scale here would force the slider into aspect-locked
             // mode and break the wheel's manual layout.
-            ( (ColorWheel)bindable )._disc.IndicatorRadiusScale = (float)newValue;
+            ((ColorWheel)bindable)._disc.IndicatorRadiusScale = (float)newValue;
         }
     }
 
     public bool Vertical
     {
-        get => (bool)GetValue( VerticalProperty );
-        set => SetValue( VerticalProperty, value );
+        get => (bool)GetValue(VerticalProperty);
+        set => SetValue(VerticalProperty, value);
     }
-    static void HandleVertical( BindableObject bindable, object oldValue, object newValue )
+    static void HandleVertical(BindableObject bindable, object oldValue, object newValue)
     {
-        if ( newValue != oldValue )
+        if (newValue != oldValue)
         {
             var wheel = (ColorWheel)bindable;
             wheel._alphaSlider.Vertical = (bool)newValue;
@@ -131,68 +131,68 @@ public class ColorWheel : ColorPickerBase
     /// </summary>
     public ColorWheel()
     {
-        _disc.AttachedColorPicker    = this;
+        _disc.AttachedColorPicker = this;
 
-        HorizontalOptions                   = LayoutOptions.Center;
-        VerticalOptions                     = LayoutOptions.Center;
+        HorizontalOptions = LayoutOptions.Center;
+        VerticalOptions = LayoutOptions.Center;
 
-        Children.Add( _disc );
+        Children.Add(_disc);
 
-        _alphaSlider.AttachedColorPicker       = this;
-        _luminositySlider.AttachedColorPicker  = this;
+        _alphaSlider.AttachedColorPicker = this;
+        _luminositySlider.AttachedColorPicker = this;
 
-        UpdateAlphaSlider( ShowAlphaSlider );
-        UpdateLuminositySlider( ShowLuminositySlider );
+        UpdateAlphaSlider(ShowAlphaSlider);
+        UpdateLuminositySlider(ShowLuminositySlider);
     }
 
-    protected override void OnSelectedColorChanging( Color color ) { }
+    protected override void OnSelectedColorChanging(Color color) { }
 
-    protected override Size MeasureOverride( double widthConstraint, double heightConstraint )
+    protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
     {
         // Apply WidthRequest/HeightRequest as constraints
-        if ( WidthRequest >= 0 )
-            widthConstraint = Math.Min( widthConstraint, WidthRequest );
-        if ( HeightRequest >= 0 )
-            heightConstraint = Math.Min( heightConstraint, HeightRequest );
+        if (WidthRequest >= 0)
+            widthConstraint = Math.Min(widthConstraint, WidthRequest);
+        if (HeightRequest >= 0)
+            heightConstraint = Math.Min(heightConstraint, HeightRequest);
 
-        if ( double.IsPositiveInfinity( widthConstraint ) &&
-             double.IsPositiveInfinity( heightConstraint ) )
+        if (double.IsPositiveInfinity(widthConstraint) &&
+             double.IsPositiveInfinity(heightConstraint))
         {
-            widthConstraint     = 200;
-            heightConstraint    = 200;
+            widthConstraint = 200;
+            heightConstraint = 200;
         }
 
-        var sliderCount = ( ShowAlphaSlider ? 1 : 0 ) + ( ShowLuminositySlider ? 1 : 0 );
+        var sliderCount = (ShowAlphaSlider ? 1 : 0) + (ShowLuminositySlider ? 1 : 0);
         var sliderFraction = 0.1 * sliderCount;
 
         double circleSize;
         double totalWidth;
         double totalHeight;
 
-        if ( Vertical )
+        if (Vertical)
         {
             // Circle fills height, sliders add to the right
-            circleSize  = Math.Min( heightConstraint, ( 1.0 - sliderFraction ) * widthConstraint );
+            circleSize = Math.Min(heightConstraint, (1.0 - sliderFraction) * widthConstraint);
             totalHeight = circleSize;
-            totalWidth  = circleSize / ( 1.0 - sliderFraction );
+            totalWidth = circleSize / (1.0 - sliderFraction);
         }
         else
         {
             // Circle fills width, sliders add below
-            circleSize  = Math.Min( widthConstraint, ( 1.0 - sliderFraction ) * heightConstraint );
-            totalWidth  = circleSize;
-            totalHeight = circleSize / ( 1.0 - sliderFraction );
+            circleSize = Math.Min(widthConstraint, (1.0 - sliderFraction) * heightConstraint);
+            totalWidth = circleSize;
+            totalHeight = circleSize / (1.0 - sliderFraction);
         }
 
-        return new Size( totalWidth, totalHeight );
+        return new Size(totalWidth, totalHeight);
     }
 
-    protected override Size ArrangeLayoutChildren( Rect bounds )
+    protected override Size ArrangeLayoutChildren(Rect bounds)
     {
         var width  = bounds.Width;
         var height = bounds.Height;
 
-        var sliderCount    = ( ShowLuminositySlider ? 1 : 0 ) + ( ShowAlphaSlider ? 1 : 0 );
+        var sliderCount    = (ShowLuminositySlider ? 1 : 0) + (ShowAlphaSlider ? 1 : 0);
         var sliderFraction = 0.1 * sliderCount;
 
         // Pick the largest circle that fits both the perpendicular axis and the
@@ -202,81 +202,81 @@ public class ColorWheel : ColorPickerBase
         double circleSize;
         double sliderThickness;
 
-        if ( Vertical )
+        if (Vertical)
         {
-            circleSize      = Math.Min( height,
-                                        sliderCount > 0 ? ( 1.0 - sliderFraction ) * width : width );
+            circleSize = Math.Min(height,
+                                        sliderCount > 0 ? (1.0 - sliderFraction) * width : width);
             sliderThickness = sliderCount > 0
-                            ? ( sliderFraction * circleSize ) / ( ( 1.0 - sliderFraction ) * sliderCount )
+                            ? (sliderFraction * circleSize) / ((1.0 - sliderFraction) * sliderCount)
                             : 0;
         }
         else
         {
-            circleSize      = Math.Min( width,
-                                        sliderCount > 0 ? ( 1.0 - sliderFraction ) * height : height );
+            circleSize = Math.Min(width,
+                                        sliderCount > 0 ? (1.0 - sliderFraction) * height : height);
             sliderThickness = sliderCount > 0
-                            ? ( sliderFraction * circleSize ) / ( ( 1.0 - sliderFraction ) * sliderCount )
+                            ? (sliderFraction * circleSize) / ((1.0 - sliderFraction) * sliderCount)
                             : 0;
         }
 
         // Bounds == natural size (parent honors our DesiredSize via HO/VO=Center),
         // so children are placed at (0,0) with no centering offset needed.
-        ( (IView)_disc ).Measure( circleSize, circleSize );
-        ( (IView)_disc ).Arrange( new Rect( 0, 0, circleSize, circleSize ) );
+        ((IView)_disc).Measure(circleSize, circleSize);
+        ((IView)_disc).Arrange(new Rect(0, 0, circleSize, circleSize));
 
-        if ( Vertical )
+        if (Vertical)
         {
             var x = circleSize;
-            if ( ShowLuminositySlider )
+            if (ShowLuminositySlider)
             {
-                ( (IView)_luminositySlider ).Measure( sliderThickness, circleSize );
-                ( (IView)_luminositySlider ).Arrange( new Rect( x, 0, sliderThickness, circleSize ) );
+                ((IView)_luminositySlider).Measure(sliderThickness, circleSize);
+                ((IView)_luminositySlider).Arrange(new Rect(x, 0, sliderThickness, circleSize));
                 x += sliderThickness;
             }
-            if ( ShowAlphaSlider )
+            if (ShowAlphaSlider)
             {
-                ( (IView)_alphaSlider ).Measure( sliderThickness, circleSize );
-                ( (IView)_alphaSlider ).Arrange( new Rect( x, 0, sliderThickness, circleSize ) );
+                ((IView)_alphaSlider).Measure(sliderThickness, circleSize);
+                ((IView)_alphaSlider).Arrange(new Rect(x, 0, sliderThickness, circleSize));
             }
         }
         else
         {
             var y = circleSize;
-            if ( ShowLuminositySlider )
+            if (ShowLuminositySlider)
             {
-                ( (IView)_luminositySlider ).Measure( circleSize, sliderThickness );
-                ( (IView)_luminositySlider ).Arrange( new Rect( 0, y, circleSize, sliderThickness ) );
+                ((IView)_luminositySlider).Measure(circleSize, sliderThickness);
+                ((IView)_luminositySlider).Arrange(new Rect(0, y, circleSize, sliderThickness));
                 y += sliderThickness;
             }
-            if ( ShowAlphaSlider )
+            if (ShowAlphaSlider)
             {
-                ( (IView)_alphaSlider ).Measure( circleSize, sliderThickness );
-                ( (IView)_alphaSlider ).Arrange( new Rect( 0, y, circleSize, sliderThickness ) );
+                ((IView)_alphaSlider).Measure(circleSize, sliderThickness);
+                ((IView)_alphaSlider).Arrange(new Rect(0, y, circleSize, sliderThickness));
             }
         }
 
         return bounds.Size;
     }
 
-    void BoundColorPicker_PropertyChanged( object sender, System.ComponentModel.PropertyChangedEventArgs e )
+    void BoundColorPicker_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
-        if ( e.PropertyName == nameof( SelectedColor ) )
-            SelectedColor = ( (IColorPicker)sender ).SelectedColor;
+        if (e.PropertyName == nameof(SelectedColor))
+            SelectedColor = ((IColorPicker)sender).SelectedColor;
     }
 
-    void UpdateAlphaSlider( bool show )
+    void UpdateAlphaSlider(bool show)
     {
-        if ( show )
-            Children.Add( _alphaSlider );
+        if (show)
+            Children.Add(_alphaSlider);
         else
-            Children.Remove( _alphaSlider );
+            Children.Remove(_alphaSlider);
     }
 
-    void UpdateLuminositySlider( bool show )
+    void UpdateLuminositySlider(bool show)
     {
-        if ( show )
-            Children.Add( _luminositySlider );
+        if (show)
+            Children.Add(_luminositySlider);
         else
-            Children.Remove( _luminositySlider );
+            Children.Remove(_luminositySlider);
     }
 }

--- a/ColorPicker/Controls/DelegateSlider.cs
+++ b/ColorPicker/Controls/DelegateSlider.cs
@@ -6,16 +6,16 @@ public class DelegateSlider : SliderBase, Interfaces.ISlider
     readonly Func<float, Color, Color>              _getNewColor;
     readonly Func<Color, SKPoint, SKPoint, SKPaint> _getPaint;
 
-    public DelegateSlider( Func<Color, float>                       newValue, 
-                   Func<float, Color, Color>                getNewColor, 
-                   Func<Color, SKPoint, SKPoint, SKPaint>   getPaint )
+    public DelegateSlider(Func<Color, float> newValue,
+                   Func<float, Color, Color> getNewColor,
+                   Func<Color, SKPoint, SKPoint, SKPaint> getPaint)
     {
-        _newValue      = newValue;
-        _getNewColor   = getNewColor;
-        _getPaint      = getPaint;
+        _newValue = newValue;
+        _getNewColor = getNewColor;
+        _getPaint = getPaint;
     }
 
-    public override Color   GetNewColor( float newValue, Color oldColor )                   => _getNewColor( newValue, oldColor );
-    public override SKPaint GetPaint( Color color, SKPoint startPoint, SKPoint endPoint )   => _getPaint( color, startPoint, endPoint );
-    public override float   NewValue( Color color )                                         => _newValue( color );
+    public override Color GetNewColor(float newValue, Color oldColor) => _getNewColor(newValue, oldColor);
+    public override SKPaint GetPaint(Color color, SKPoint startPoint, SKPoint endPoint) => _getPaint(color, startPoint, endPoint);
+    public override float NewValue(Color color) => _newValue(color);
 }

--- a/ColorPicker/Controls/HslSlider.cs
+++ b/ColorPicker/Controls/HslSlider.cs
@@ -6,28 +6,28 @@ public class HslSlider : SliderStackWithAlpha
     {
         var result = new List<DelegateSlider>()
             {
-                new DelegateSlider( HslSliderFactory.NewValueH,
+                new DelegateSlider(HslSliderFactory.NewValueH,
                             HslSliderFactory.GetNewColorH,
-                            HslSliderFactory.GetPaintH ),
+                            HslSliderFactory.GetPaintH),
 
-                new DelegateSlider( HslSliderFactory.NewValueS,
+                new DelegateSlider(HslSliderFactory.NewValueS,
                             HslSliderFactory.GetNewColorS,
                             HslSliderFactory.GetPaintS),
 
-                new DelegateSlider( HslSliderFactory.NewValueL,
+                new DelegateSlider(HslSliderFactory.NewValueL,
                             HslSliderFactory.GetNewColorL,
-                            HslSliderFactory.GetPaintL )
+                            HslSliderFactory.GetPaintL)
             };
 
-        if ( ShowAlphaSlider )
+        if (ShowAlphaSlider)
         {
-            var slider = new DelegateSlider( AlphaSliderFactory.NewValueAlpha,
+            var slider = new DelegateSlider(AlphaSliderFactory.NewValueAlpha,
                                      AlphaSliderFactory.GetNewColorAlpha,
-                                     AlphaSliderFactory.GetPaintAlpha )
+                                     AlphaSliderFactory.GetPaintAlpha)
             {
                 PaintChessPattern = true
             };
-            result.Add( slider );
+            result.Add(slider);
         }
 
         return result;

--- a/ColorPicker/Controls/HslSliderFactory.cs
+++ b/ColorPicker/Controls/HslSliderFactory.cs
@@ -2,51 +2,51 @@ namespace ColorPicker.Controls;
 
 public static class HslSliderFactory
 {
-    public static float NewValueH( Color color ) => color.GetHue();
-    public static float NewValueS( Color color ) => color.GetSaturation();
-    public static float NewValueL( Color color ) => color.GetLuminosity();
+    public static float NewValueH(Color color) => color.GetHue();
+    public static float NewValueS(Color color) => color.GetSaturation();
+    public static float NewValueL(Color color) => color.GetLuminosity();
 
-    public static Color GetNewColorH( float newValue, Color oldColor ) 
-            => Color.FromHsla( newValue, oldColor.GetSaturation(), oldColor.GetLuminosity(), oldColor.Alpha );
+    public static Color GetNewColorH(float newValue, Color oldColor)
+            => Color.FromHsla(newValue, oldColor.GetSaturation(), oldColor.GetLuminosity(), oldColor.Alpha);
 
-    public static Color GetNewColorS( float newValue, Color oldColor ) 
-            => Color.FromHsla( oldColor.GetHue(), newValue, oldColor.GetLuminosity(), oldColor.Alpha );
+    public static Color GetNewColorS(float newValue, Color oldColor)
+            => Color.FromHsla(oldColor.GetHue(), newValue, oldColor.GetLuminosity(), oldColor.Alpha);
 
-    public static Color GetNewColorL( float newValue, Color oldColor ) 
-            => Color.FromHsla( oldColor.GetHue(), oldColor.GetSaturation(), newValue, oldColor.Alpha );
+    public static Color GetNewColorL(float newValue, Color oldColor)
+            => Color.FromHsla(oldColor.GetHue(), oldColor.GetSaturation(), newValue, oldColor.Alpha);
 
-    public static SKPaint GetPaintH( Color _, SKPoint startPoint, SKPoint endPoint )
+    public static SKPaint GetPaintH(Color _, SKPoint startPoint, SKPoint endPoint)
     {
         var colors = new List<SKColor>();
 
-        for ( var i = 0; i <= 255; i++ )
+        for (var i = 0; i <= 255; i++)
         {
-            colors.Add( Color.FromHsla( i / 255D, 1.0, 0.5 ).ToSKColor() );
+            colors.Add(Color.FromHsla(i / 255D, 1.0, 0.5).ToSKColor());
         }
 
         var colorPos = new List<float>();
 
-        for ( var i = 0; i <= 255; i++ )
+        for (var i = 0; i <= 255; i++)
         {
-            colorPos.Add( i / 255F );
+            colorPos.Add(i / 255F);
         }
 
-        return GetPaint( colors.ToArray(), colorPos.ToArray(), startPoint, endPoint );
+        return GetPaint(colors.ToArray(), colorPos.ToArray(), startPoint, endPoint);
     }
 
-    public static SKPaint GetPaintS( Color color, SKPoint startPoint, SKPoint endPoint )
+    public static SKPaint GetPaintS(Color color, SKPoint startPoint, SKPoint endPoint)
     {
         var colors = new SKColor[]
             {
-                Color.FromHsla( color.GetHue(), 0.0, color.GetLuminosity() ).ToSKColor(),
-                Color.FromHsla( color.GetHue(), 1.0, color.GetLuminosity() ).ToSKColor()
+                Color.FromHsla(color.GetHue(), 0.0, color.GetLuminosity()).ToSKColor(),
+                Color.FromHsla(color.GetHue(), 1.0, color.GetLuminosity()).ToSKColor()
             };
 
         var colorPos = new float[] { 0F, 1F };
-        return GetPaint( colors, colorPos, startPoint, endPoint );
+        return GetPaint(colors, colorPos, startPoint, endPoint);
     }
 
-    public static SKPaint GetPaintL( Color color, SKPoint startPoint, SKPoint endPoint )
+    public static SKPaint GetPaintL(Color color, SKPoint startPoint, SKPoint endPoint)
     {
         var colors = new SKColor[]
             {
@@ -56,12 +56,12 @@ public static class HslSliderFactory
             };
 
         var colorPos = new float[] { 0F, 0.5F, 1F };
-        return GetPaint( colors, colorPos, startPoint, endPoint );
+        return GetPaint(colors, colorPos, startPoint, endPoint);
     }
 
-    public static SKPaint GetPaint( SKColor[ ] colors, float[ ] colorPos, SKPoint startPoint, SKPoint endPoint )
+    public static SKPaint GetPaint(SKColor[] colors, float[] colorPos, SKPoint startPoint, SKPoint endPoint)
     {
-        var shader = SKShader.CreateLinearGradient(startPoint, endPoint, 
+        var shader = SKShader.CreateLinearGradient(startPoint, endPoint,
                                                         colors, colorPos, SKShaderTileMode.Clamp);
         var paint = new SKPaint()
         {

--- a/ColorPicker/Controls/LuminositySlider.cs
+++ b/ColorPicker/Controls/LuminositySlider.cs
@@ -2,11 +2,11 @@ namespace ColorPicker.Controls;
 
 public class LuminositySlider : SliderStack
 {
-    protected override IEnumerable<SliderBase> GetSliders() 
-        =>  new SliderBase[]
+    protected override IEnumerable<SliderBase> GetSliders()
+        => new SliderBase[]
             {
-                new DelegateSlider( HslSliderFactory.NewValueL, 
-                            HslSliderFactory.GetNewColorL, 
-                            HslSliderFactory.GetPaintL )
+                new DelegateSlider(HslSliderFactory.NewValueL,
+                            HslSliderFactory.GetNewColorL,
+                            HslSliderFactory.GetPaintL)
             };
 }

--- a/ColorPicker/Controls/RgbSlider.cs
+++ b/ColorPicker/Controls/RgbSlider.cs
@@ -6,28 +6,28 @@ public class RgbSlider : SliderStackWithAlpha
     {
         var result = new List<DelegateSlider>()
             {
-                new DelegateSlider( RgbSliderFactory.NewValueR,
+                new DelegateSlider(RgbSliderFactory.NewValueR,
                             RgbSliderFactory.GetNewColorR,
-                            RgbSliderFactory.GetPaintR ),
+                            RgbSliderFactory.GetPaintR),
 
-                new DelegateSlider( RgbSliderFactory.NewValueG,
+                new DelegateSlider(RgbSliderFactory.NewValueG,
                             RgbSliderFactory.GetNewColorG,
-                            RgbSliderFactory.GetPaintG ),
+                            RgbSliderFactory.GetPaintG),
 
-                new DelegateSlider( RgbSliderFactory.NewValueB,
+                new DelegateSlider(RgbSliderFactory.NewValueB,
                             RgbSliderFactory.GetNewColorB,
-                            RgbSliderFactory.GetPaintB )
+                            RgbSliderFactory.GetPaintB)
             };
 
-        if ( ShowAlphaSlider )
+        if (ShowAlphaSlider)
         {
-            var slider = new DelegateSlider( AlphaSliderFactory.NewValueAlpha,
+            var slider = new DelegateSlider(AlphaSliderFactory.NewValueAlpha,
                                      AlphaSliderFactory.GetNewColorAlpha,
-                                     AlphaSliderFactory.GetPaintAlpha )
+                                     AlphaSliderFactory.GetPaintAlpha)
             {
                 PaintChessPattern = true
             };
-            result.Add( slider );
+            result.Add(slider);
         }
 
         return result;

--- a/ColorPicker/Controls/RgbSliderFactory.cs
+++ b/ColorPicker/Controls/RgbSliderFactory.cs
@@ -2,41 +2,41 @@ namespace ColorPicker.Controls;
 
 public static class RgbSliderFactory
 {
-    public static float NewValueR( Color color ) => color.Red;
-    public static float NewValueG( Color color ) => color.Green;
-    public static float NewValueB( Color color ) => color.Blue;
+    public static float NewValueR(Color color) => color.Red;
+    public static float NewValueG(Color color) => color.Green;
+    public static float NewValueB(Color color) => color.Blue;
 
-    public static Color GetNewColorR( float newValue, Color oldColor ) 
-            => Color.FromRgba( newValue, oldColor.Green, oldColor.Blue, oldColor.Alpha );
+    public static Color GetNewColorR(float newValue, Color oldColor)
+            => Color.FromRgba(newValue, oldColor.Green, oldColor.Blue, oldColor.Alpha);
 
-    public static Color GetNewColorG( float newValue, Color oldColor ) 
-            => Color.FromRgba( oldColor.Red, newValue, oldColor.Blue, oldColor.Alpha );
+    public static Color GetNewColorG(float newValue, Color oldColor)
+            => Color.FromRgba(oldColor.Red, newValue, oldColor.Blue, oldColor.Alpha);
 
-    public static Color GetNewColorB( float newValue, Color oldColor ) 
-            => Color.FromRgba( oldColor.Red, oldColor.Green, newValue, oldColor.Alpha );
+    public static Color GetNewColorB(float newValue, Color oldColor)
+            => Color.FromRgba(oldColor.Red, oldColor.Green, newValue, oldColor.Alpha);
 
-    public static SKPaint GetPaintR( Color color, SKPoint startPoint, SKPoint endPoint )
+    public static SKPaint GetPaintR(Color color, SKPoint startPoint, SKPoint endPoint)
     {
         var startColor = new Color(0, color.Green, color.Blue).ToSKColor();
         var endColor = new Color(1, color.Green, color.Blue).ToSKColor();
-        return GetPaint( startColor, endColor, startPoint, endPoint );
+        return GetPaint(startColor, endColor, startPoint, endPoint);
     }
 
-    public static SKPaint GetPaintG( Color color, SKPoint startPoint, SKPoint endPoint )
+    public static SKPaint GetPaintG(Color color, SKPoint startPoint, SKPoint endPoint)
     {
         var startColor = new Color(color.Red, 0, color.Blue).ToSKColor();
         var endColor = new Color(color.Red, 1, color.Blue).ToSKColor();
-        return GetPaint( startColor, endColor, startPoint, endPoint );
+        return GetPaint(startColor, endColor, startPoint, endPoint);
     }
 
-    public static SKPaint GetPaintB( Color color, SKPoint startPoint, SKPoint endPoint )
+    public static SKPaint GetPaintB(Color color, SKPoint startPoint, SKPoint endPoint)
     {
         var startColor = new Color(color.Red, color.Green, 0).ToSKColor();
         var endColor = new Color(color.Red, color.Green, 1).ToSKColor();
-        return GetPaint( startColor, endColor, startPoint, endPoint );
+        return GetPaint(startColor, endColor, startPoint, endPoint);
     }
 
-    public static SKPaint GetPaint( SKColor startColor, SKColor endColor, SKPoint startPoint, SKPoint endPoint )
+    public static SKPaint GetPaint(SKColor startColor, SKColor endColor, SKPoint startPoint, SKPoint endPoint)
     {
         var paint = new SKPaint()
         {
@@ -44,7 +44,7 @@ public static class RgbSliderFactory
             Style       = SKPaintStyle.Stroke,
             StrokeCap   = SKStrokeCap.Round,
             StrokeJoin  = SKStrokeJoin.Round,
-            Shader      = SKShader.CreateLinearGradient(startPoint, endPoint, new SKColor[] { startColor, endColor }, 
+            Shader      = SKShader.CreateLinearGradient(startPoint, endPoint, new SKColor[] { startColor, endColor },
                                                         new float[] { 0, 1 }, SKShaderTileMode.Clamp)
         };
         return paint;

--- a/ColorPicker/Interfaces/IColorPicker.cs
+++ b/ColorPicker/Interfaces/IColorPicker.cs
@@ -2,6 +2,6 @@
 
 public interface IColorPicker : INotifyPropertyChanged
 {
-    Color        SelectedColor          { get; set; }
-    IColorPicker AttachedColorPicker    { get; set; }
+    Color SelectedColor { get; set; }
+    IColorPicker AttachedColorPicker { get; set; }
 }

--- a/ColorPicker/Interfaces/ISlider.cs
+++ b/ColorPicker/Interfaces/ISlider.cs
@@ -2,9 +2,9 @@ namespace ColorPicker.Interfaces;
 
 public interface ISlider
 {
-    public bool     PaintChessPattern { get; set; }
- 
-    public float    NewValue( Color color );
-    public Color    GetNewColor( float newValue, Color oldColor );
-    public SKPaint  GetPaint(Color color, SKPoint startPoint, SKPoint endPoint);
+    public bool PaintChessPattern { get; set; }
+
+    public float NewValue(Color color);
+    public Color GetNewColor(float newValue, Color oldColor);
+    public SKPaint GetPaint(Color color, SKPoint startPoint, SKPoint endPoint);
 }

--- a/ColorPicker/Platforms/Android/AndroidTouchActionBehavior.cs
+++ b/ColorPicker/Platforms/Android/AndroidTouchActionBehavior.cs
@@ -15,54 +15,54 @@ public class AndroidTouchActionBehavior : Behavior<SkiaPickerBase>
     static readonly Dictionary<Android.Views.View, AndroidTouchActionBehavior> _viewDictionary       = new();
     static readonly Dictionary<int, AndroidTouchActionBehavior>                _idToEffectDictionary = new();
 
-    public AndroidTouchActionBehavior( TouchBehavior sharedBehavior )
+    public AndroidTouchActionBehavior(TouchBehavior sharedBehavior)
     {
-        ArgumentNullException.ThrowIfNull( sharedBehavior );
+        ArgumentNullException.ThrowIfNull(sharedBehavior);
 
         _commonBehavior = sharedBehavior;
     }
 
-    protected override void OnAttachedTo( SkiaPickerBase bindable )
+    protected override void OnAttachedTo(SkiaPickerBase bindable)
     {
         bindable.HandlerChanged += OnHandlerChangedAction;
-        base.OnAttachedTo( bindable );
+        base.OnAttachedTo(bindable);
     }
 
-    void OnHandlerChangedAction( object sender, EventArgs e )
+    void OnHandlerChangedAction(object sender, EventArgs e)
     {
-        if ( sender is not SkiaPickerBase bindable )
+        if (sender is not SkiaPickerBase bindable)
             return;
 
         var mauiContext =   bindable.Handler.MauiContext ?? bindable.Parent.Handler.MauiContext;
 
         // Get the Android View corresponding to the Element that the effect is attached to
-        _nativeView =   bindable.ToPlatform( mauiContext );
+        _nativeView = bindable.ToPlatform(mauiContext);
 
-        if ( _commonBehavior is null || _nativeView is null )
+        if (_commonBehavior is null || _nativeView is null)
             return;
 
-        _viewDictionary.Add( _nativeView, this );
+        _viewDictionary.Add(_nativeView, this);
         _formsElement = bindable;
 
         // Save fromPixels function
-        _fromPixels     = _nativeView.Context.FromPixels;
+        _fromPixels = _nativeView.Context.FromPixels;
 
         // Set event handler on View
         _nativeView.Touch += OnTouch;
     }
 
-    protected override void OnDetachingFrom( SkiaPickerBase bindable )
+    protected override void OnDetachingFrom(SkiaPickerBase bindable)
     {
-        if ( _viewDictionary.ContainsKey( _nativeView ) )
+        if (_viewDictionary.ContainsKey(_nativeView))
         {
-            _viewDictionary.Remove( _nativeView );
+            _viewDictionary.Remove(_nativeView);
             _nativeView.Touch -= OnTouch;
         }
 
-        base.OnDetachingFrom( bindable );
+        base.OnDetachingFrom(bindable);
     }
 
-    void OnTouch( object sender, Android.Views.View.TouchEventArgs args )
+    void OnTouch(object sender, Android.Views.View.TouchEventArgs args)
     {
         // Two object common to all the events
         var senderView = sender as Android.Views.View;
@@ -74,45 +74,45 @@ public class AndroidTouchActionBehavior : Behavior<SkiaPickerBase>
         // Get the id that identifies a finger over the course of its progress
         var id = motionEvent.GetPointerId(pointerIndex);
 
-        senderView.GetLocationOnScreen( _screenLocationArray );
+        senderView.GetLocationOnScreen(_screenLocationArray);
 
         Point screenPointerCoords = new(_screenLocationArray[0] + motionEvent.GetX(pointerIndex),
                                         _screenLocationArray[1] + motionEvent.GetY(pointerIndex));
 
         // Use ActionMasked here rather than Action to reduce the number of possibilities
-        switch ( args.Event.ActionMasked )
+        switch (args.Event.ActionMasked)
         {
             case MotionEventActions.Down:
             case MotionEventActions.PointerDown:
-                FireEvent( this, id, TouchActionType.Pressed, screenPointerCoords, true );
+                FireEvent(this, id, TouchActionType.Pressed, screenPointerCoords, true);
 
-                _idToEffectDictionary.Add( id, this );
+                _idToEffectDictionary.Add(id, this);
 
                 _capture = _commonBehavior.Capture;
                 break;
 
             case MotionEventActions.Move:
                 // Multiple Move events are bundled, so handle them in a loop
-                for ( pointerIndex = 0; pointerIndex < motionEvent.PointerCount; pointerIndex++ )
+                for (pointerIndex = 0; pointerIndex < motionEvent.PointerCount; pointerIndex++)
                 {
-                    id = motionEvent.GetPointerId( pointerIndex );
+                    id = motionEvent.GetPointerId(pointerIndex);
 
-                    if ( _capture )
+                    if (_capture)
                     {
-                        senderView.GetLocationOnScreen( _screenLocationArray );
+                        senderView.GetLocationOnScreen(_screenLocationArray);
 
-                        screenPointerCoords = new Point( _screenLocationArray[ 0 ] + motionEvent.GetX( pointerIndex ),
-                                                         _screenLocationArray[ 1 ] + motionEvent.GetY( pointerIndex ) );
+                        screenPointerCoords = new Point(_screenLocationArray[0] + motionEvent.GetX(pointerIndex),
+                                                         _screenLocationArray[1] + motionEvent.GetY(pointerIndex));
 
-                        FireEvent( this, id, TouchActionType.Moved, screenPointerCoords, true );
+                        FireEvent(this, id, TouchActionType.Moved, screenPointerCoords, true);
                     }
                     else
                     {
-                        CheckForBoundaryHop( id, screenPointerCoords );
+                        CheckForBoundaryHop(id, screenPointerCoords);
 
-                        if ( _idToEffectDictionary[ id ] is not null )
+                        if (_idToEffectDictionary[id] is not null)
                         {
-                            FireEvent( _idToEffectDictionary[ id ], id, TouchActionType.Moved, screenPointerCoords, true );
+                            FireEvent(_idToEffectDictionary[id], id, TouchActionType.Moved, screenPointerCoords, true);
                         }
                     }
                 }
@@ -121,96 +121,96 @@ public class AndroidTouchActionBehavior : Behavior<SkiaPickerBase>
 
             case MotionEventActions.Up:
             case MotionEventActions.Pointer1Up:
-                if ( _capture )
+                if (_capture)
                 {
-                    FireEvent( this, id, TouchActionType.Released, screenPointerCoords, false );
+                    FireEvent(this, id, TouchActionType.Released, screenPointerCoords, false);
                 }
                 else
                 {
-                    CheckForBoundaryHop( id, screenPointerCoords );
+                    CheckForBoundaryHop(id, screenPointerCoords);
 
-                    if ( _idToEffectDictionary[ id ] is not null )
+                    if (_idToEffectDictionary[id] is not null)
                     {
-                        FireEvent( _idToEffectDictionary[ id ], id, TouchActionType.Released, screenPointerCoords, false );
+                        FireEvent(_idToEffectDictionary[id], id, TouchActionType.Released, screenPointerCoords, false);
                     }
                 }
 
-                _idToEffectDictionary.Remove( id );
+                _idToEffectDictionary.Remove(id);
                 break;
 
             case MotionEventActions.Cancel:
-                if ( _capture )
+                if (_capture)
                 {
-                    FireEvent( this, id, TouchActionType.Cancelled, screenPointerCoords, false );
+                    FireEvent(this, id, TouchActionType.Cancelled, screenPointerCoords, false);
                 }
                 else
                 {
-                    if ( _idToEffectDictionary[ id ] is not null )
+                    if (_idToEffectDictionary[id] is not null)
                     {
-                        FireEvent( _idToEffectDictionary[ id ], id, TouchActionType.Cancelled, screenPointerCoords, false );
+                        FireEvent(_idToEffectDictionary[id], id, TouchActionType.Cancelled, screenPointerCoords, false);
                     }
                 }
 
-                _idToEffectDictionary.Remove( id );
+                _idToEffectDictionary.Remove(id);
                 break;
         }
     }
 
-    void CheckForBoundaryHop( int id, Point pointerLocation )
+    void CheckForBoundaryHop(int id, Point pointerLocation)
     {
         AndroidTouchActionBehavior touchEffectHit = null;
 
-        foreach ( var view in _viewDictionary.Keys )
+        foreach (var view in _viewDictionary.Keys)
         {
             // Get the view rectangle
             try
             {
-                view.GetLocationOnScreen( _screenLocationArray );
+                view.GetLocationOnScreen(_screenLocationArray);
             }
             catch // System.ObjectDisposedException: Cannot access a disposed object.
             {
                 continue;
             }
 
-            Rect viewRect = new( _screenLocationArray[0], 
-                                      _screenLocationArray[1], 
-                                      view.Width, 
-                                      view.Height );
+            Rect viewRect = new(_screenLocationArray[0],
+                                      _screenLocationArray[1],
+                                      view.Width,
+                                      view.Height);
 
-            if ( viewRect.Contains( pointerLocation ) )
+            if (viewRect.Contains(pointerLocation))
             {
-                touchEffectHit = _viewDictionary[ view ];
+                touchEffectHit = _viewDictionary[view];
             }
         }
 
-        if ( touchEffectHit != _idToEffectDictionary[ id ] )
+        if (touchEffectHit != _idToEffectDictionary[id])
         {
-            if ( _idToEffectDictionary[ id ] is not null )
+            if (_idToEffectDictionary[id] is not null)
             {
-                FireEvent( _idToEffectDictionary[ id ], id, TouchActionType.Exited, pointerLocation, true );
+                FireEvent(_idToEffectDictionary[id], id, TouchActionType.Exited, pointerLocation, true);
             }
 
-            if ( touchEffectHit is not null )
+            if (touchEffectHit is not null)
             {
-                FireEvent( touchEffectHit, id, TouchActionType.Entered, pointerLocation, true );
+                FireEvent(touchEffectHit, id, TouchActionType.Entered, pointerLocation, true);
             }
 
-            _idToEffectDictionary[ id ] = touchEffectHit;
+            _idToEffectDictionary[id] = touchEffectHit;
         }
     }
 
-    void FireEvent( AndroidTouchActionBehavior behavior, int id, TouchActionType actionType, Point pointerLocation, bool isInContact )
+    void FireEvent(AndroidTouchActionBehavior behavior, int id, TouchActionType actionType, Point pointerLocation, bool isInContact)
     {
         // Get the location of the pointer within the view
-        behavior._nativeView.GetLocationOnScreen( _screenLocationArray );
+        behavior._nativeView.GetLocationOnScreen(_screenLocationArray);
 
         var x = pointerLocation.X - _screenLocationArray[0];
         var y = pointerLocation.Y - _screenLocationArray[1];
 
-        Point point = new( _fromPixels(x), _fromPixels(y) );
+        Point point = new(_fromPixels(x), _fromPixels(y));
 
         // Call the method
-        behavior._commonBehavior.OnTouchAction( behavior._formsElement, 
-                                                new TouchActionEventArgs( id, actionType, point, isInContact ) );
+        behavior._commonBehavior.OnTouchAction(behavior._formsElement,
+                                                new TouchActionEventArgs(id, actionType, point, isInContact));
     }
 }

--- a/ColorPicker/Platforms/Windows/WindowsTouchActionBehavior.cs
+++ b/ColorPicker/Platforms/Windows/WindowsTouchActionBehavior.cs
@@ -10,98 +10,98 @@ public class WindowsTouchActionBehavior : Behavior<SkiaPickerBase>
     TouchBehavior                            _sharedBehavior;
     Element                                             _boundElement;
 
-    public WindowsTouchActionBehavior( TouchBehavior sharedBehavior )
+    public WindowsTouchActionBehavior(TouchBehavior sharedBehavior)
     {
-        ArgumentNullException.ThrowIfNull( sharedBehavior );
+        ArgumentNullException.ThrowIfNull(sharedBehavior);
 
         _sharedBehavior = sharedBehavior;
     }
 
-    protected override void OnAttachedTo( BindableObject sender )
+    protected override void OnAttachedTo(BindableObject sender)
     {
-        if ( sender is not SkiaPickerBase bindable )
+        if (sender is not SkiaPickerBase bindable)
             return;
 
-        bindable.HandlerChanged     += OnHandlerChanged;
-        base.OnAttachedTo( bindable );
+        bindable.HandlerChanged += OnHandlerChanged;
+        base.OnAttachedTo(bindable);
     }
 
-    void OnHandlerChanged( object sender, EventArgs e )
+    void OnHandlerChanged(object sender, EventArgs e)
     {
-        if ( sender is not SkiaPickerBase bindable )
+        if (sender is not SkiaPickerBase bindable)
             return;
 
         // Get the Windows FrameworkElement corresponding to the Element that the Behavior is attached to
-        _boundElement       =   bindable;
+        _boundElement = bindable;
         var context         =   bindable.Handler.MauiContext ?? bindable.Parent.Handler.MauiContext;
-        _frameworkElement   =   bindable.ToPlatform( context );
+        _frameworkElement = bindable.ToPlatform(context);
 
-        if ( _sharedBehavior is not null && _frameworkElement is not null )
+        if (_sharedBehavior is not null && _frameworkElement is not null)
         {
             // Save the method to call on touch events
             _onTouchAction = _sharedBehavior.OnTouchAction;
 
             // Set event handlers on FrameworkElement
-            _frameworkElement.PointerEntered    += OnPointerEntered;
-            _frameworkElement.PointerPressed    += OnPointerPressed;
-            _frameworkElement.PointerMoved      += OnPointerMoved;
-            _frameworkElement.PointerReleased   += OnPointerReleased;
-            _frameworkElement.PointerExited     += OnPointerExited;
-            _frameworkElement.PointerCanceled   += OnPointerCancelled;
+            _frameworkElement.PointerEntered += OnPointerEntered;
+            _frameworkElement.PointerPressed += OnPointerPressed;
+            _frameworkElement.PointerMoved += OnPointerMoved;
+            _frameworkElement.PointerReleased += OnPointerReleased;
+            _frameworkElement.PointerExited += OnPointerExited;
+            _frameworkElement.PointerCanceled += OnPointerCancelled;
         }
     }
 
-    protected override void OnDetachingFrom( SkiaPickerBase bindable )
+    protected override void OnDetachingFrom(SkiaPickerBase bindable)
     {
         bindable.HandlerChanged -= OnHandlerChanged;
 
-        if ( _onTouchAction is not null )
+        if (_onTouchAction is not null)
         {
             // Release event handlers on FrameworkElement
-            _frameworkElement.PointerEntered    -= OnPointerEntered;
-            _frameworkElement.PointerPressed    -= OnPointerPressed;
-            _frameworkElement.PointerMoved      -= OnPointerMoved;
-            _frameworkElement.PointerReleased   -= OnPointerReleased;
-            _frameworkElement.PointerExited     -= OnPointerEntered;
-            _frameworkElement.PointerCanceled   -= OnPointerCancelled;
+            _frameworkElement.PointerEntered -= OnPointerEntered;
+            _frameworkElement.PointerPressed -= OnPointerPressed;
+            _frameworkElement.PointerMoved -= OnPointerMoved;
+            _frameworkElement.PointerReleased -= OnPointerReleased;
+            _frameworkElement.PointerExited -= OnPointerEntered;
+            _frameworkElement.PointerCanceled -= OnPointerCancelled;
         }
 
-        base.OnDetachingFrom( bindable );
+        base.OnDetachingFrom(bindable);
     }
 
-    void OnPointerEntered( object sender, PointerRoutedEventArgs args )
-            => CommonHandler( sender, TouchActionType.Entered, args );
+    void OnPointerEntered(object sender, PointerRoutedEventArgs args)
+            => CommonHandler(sender, TouchActionType.Entered, args);
 
-    void OnPointerMoved( object sender, PointerRoutedEventArgs args )
-            => CommonHandler( sender, TouchActionType.Moved, args );
+    void OnPointerMoved(object sender, PointerRoutedEventArgs args)
+            => CommonHandler(sender, TouchActionType.Moved, args);
 
-    void OnPointerReleased( object sender, PointerRoutedEventArgs args )
-            => CommonHandler( sender, TouchActionType.Released, args );
+    void OnPointerReleased(object sender, PointerRoutedEventArgs args)
+            => CommonHandler(sender, TouchActionType.Released, args);
 
-    void OnPointerExited( object sender, PointerRoutedEventArgs args )
-            => CommonHandler( sender, TouchActionType.Exited, args );
+    void OnPointerExited(object sender, PointerRoutedEventArgs args)
+            => CommonHandler(sender, TouchActionType.Exited, args);
 
-    void OnPointerCancelled( object sender, PointerRoutedEventArgs args )
-            => CommonHandler( sender, TouchActionType.Cancelled, args );
+    void OnPointerCancelled(object sender, PointerRoutedEventArgs args)
+            => CommonHandler(sender, TouchActionType.Cancelled, args);
 
-    void OnPointerPressed( object sender, PointerRoutedEventArgs args )
+    void OnPointerPressed(object sender, PointerRoutedEventArgs args)
     {
-        CommonHandler( sender, TouchActionType.Pressed, args );
+        CommonHandler(sender, TouchActionType.Pressed, args);
 
         // Check setting of Capture property
-        if ( _sharedBehavior.Capture )
-            ( sender as FrameworkElement ).CapturePointer( args.Pointer );
+        if (_sharedBehavior.Capture)
+            (sender as FrameworkElement).CapturePointer(args.Pointer);
     }
 
-    void CommonHandler( object sender, TouchActionType touchActionType, PointerRoutedEventArgs args )
+    void CommonHandler(object sender, TouchActionType touchActionType, PointerRoutedEventArgs args)
     {
-        var pointerPoint                    = args.GetCurrentPoint( sender as UIElement );
+        var pointerPoint                    = args.GetCurrentPoint(sender as UIElement);
         Windows.Foundation.Point winPoint   = pointerPoint.Position;
 
-        _onTouchAction( _boundElement,
-                        new TouchActionEventArgs( args.Pointer.PointerId,
+        _onTouchAction(_boundElement,
+                        new TouchActionEventArgs(args.Pointer.PointerId,
                                                              touchActionType,
-                                                             new Point( winPoint.X, winPoint.Y ),
-                                                             args.Pointer.IsInContact ) );
+                                                             new Point(winPoint.X, winPoint.Y),
+                                                             args.Pointer.IsInContact));
     }
 }

--- a/ColorPickerTestApp/App.xaml.cs
+++ b/ColorPickerTestApp/App.xaml.cs
@@ -2,37 +2,37 @@
 
 public partial class App : Application
 {
-	public App()
-	{
-		InitializeComponent();
+    public App()
+    {
+        InitializeComponent();
 
-		// Allow UI tests to launch alternate harnesses via env vars:
-		//   LAYOUT_TEST=1 → LayoutTestPage (parameterized layout/visual probes)
-		//   SYNC_TEST=1   → ColorSyncTestPage (all controls bound to one color, sync tests)
-		var layoutTest = Environment.GetEnvironmentVariable("LAYOUT_TEST");
-		var syncTest   = Environment.GetEnvironmentVariable("SYNC_TEST");
-		MainPage = string.Equals(syncTest, "1", StringComparison.Ordinal)
-			? new ColorSyncTestPage()
-			: string.Equals(layoutTest, "1", StringComparison.Ordinal)
-				? new LayoutTestPage()
-				: new MainPage();
-	}
+        // Allow UI tests to launch alternate harnesses via env vars:
+        //   LAYOUT_TEST=1 → LayoutTestPage (parameterized layout/visual probes)
+        //   SYNC_TEST=1   → ColorSyncTestPage (all controls bound to one color, sync tests)
+        var layoutTest = Environment.GetEnvironmentVariable("LAYOUT_TEST");
+        var syncTest   = Environment.GetEnvironmentVariable("SYNC_TEST");
+        MainPage = string.Equals(syncTest, "1", StringComparison.Ordinal)
+            ? new ColorSyncTestPage()
+            : string.Equals(layoutTest, "1", StringComparison.Ordinal)
+                ? new LayoutTestPage()
+                : new MainPage();
+    }
 
-	protected override Window CreateWindow(IActivationState? activationState)
-	{
-		var window = base.CreateWindow(activationState);
-		// Pin window to a fixed logical size when running UI tests so that
-		// `fill*` / `auto*` scenarios are deterministic across machines
-		// (laptop, CI runner, different monitor resolutions).
-		var isTest = string.Equals(Environment.GetEnvironmentVariable("LAYOUT_TEST"), "1", StringComparison.Ordinal)
-		          || string.Equals(Environment.GetEnvironmentVariable("SYNC_TEST"),   "1", StringComparison.Ordinal);
-		if (isTest)
-		{
-			window.X = 0;
-			window.Y = 0;
-			window.Width  = 1280;
-			window.Height = 1024;
-		}
-		return window;
-	}
+    protected override Window CreateWindow(IActivationState? activationState)
+    {
+        var window = base.CreateWindow(activationState);
+        // Pin window to a fixed logical size when running UI tests so that
+        // `fill*` / `auto*` scenarios are deterministic across machines
+        // (laptop, CI runner, different monitor resolutions).
+        var isTest = string.Equals(Environment.GetEnvironmentVariable("LAYOUT_TEST"), "1", StringComparison.Ordinal)
+                  || string.Equals(Environment.GetEnvironmentVariable("SYNC_TEST"),   "1", StringComparison.Ordinal);
+        if (isTest)
+        {
+            window.X = 0;
+            window.Y = 0;
+            window.Width = 1280;
+            window.Height = 1024;
+        }
+        return window;
+    }
 }

--- a/ColorPickerTestApp/ColorSyncTestPage.xaml.cs
+++ b/ColorPickerTestApp/ColorSyncTestPage.xaml.cs
@@ -80,14 +80,14 @@ public partial class ColorSyncTestPage : ContentPage
             // Convention: #RRGGBBAA
             r = (byte)((v >> 24) & 0xFF);
             g = (byte)((v >> 16) & 0xFF);
-            b = (byte)((v >>  8) & 0xFF);
-            a = (byte)(v         & 0xFF);
+            b = (byte)((v >> 8) & 0xFF);
+            a = (byte)(v & 0xFF);
         }
         else
         {
             r = (byte)((v >> 16) & 0xFF);
-            g = (byte)((v >>  8) & 0xFF);
-            b = (byte)(v         & 0xFF);
+            g = (byte)((v >> 8) & 0xFF);
+            b = (byte)(v & 0xFF);
         }
         return Color.FromRgba(r, g, b, a);
     }

--- a/ColorPickerTestApp/Converters/BoolToSwitchConverter.cs
+++ b/ColorPickerTestApp/Converters/BoolToSwitchConverter.cs
@@ -4,9 +4,9 @@ using System.Globalization;
 
 public class BoolToSwitchConverter : IValueConverter
 {
-    public object Convert( object value, Type targetType, object parameter, CultureInfo culture )
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
             => (bool)value ? "Show Wheel" : "Show Triangle";
 
-    public object ConvertBack( object value, Type targetType, object parameter, CultureInfo culture )
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
             => (string)value == "Show Wheel";
 }

--- a/ColorPickerTestApp/Converters/ColorConverterExtensions.cs
+++ b/ColorPickerTestApp/Converters/ColorConverterExtensions.cs
@@ -3,110 +3,110 @@
 public static class ColorConverterExtensions
 {
     //  To... functions
-    public static string ToHexRgbString( this Color c )     =>  $"#{c.GetByteRed():X2}{c.GetByteGreen():X2}{c.GetByteBlue():X2}";
-    public static string ToHexRgbaString( this Color c )    =>  $"#{c.GetByteRed():X2}{c.GetByteGreen():X2}{c.GetByteBlue():X2}{c.GetByteAlpha():X2}";
-    public static string ToHexArgbString( this Color c )    =>  $"#{c.GetByteAlpha():X2}{c.GetByteRed():X2}{c.GetByteGreen():X2}{c.GetByteBlue():X2}";
-    public static string ToRgbString( this Color c )        =>  $"RGB({c.GetByteRed()},{c.GetByteGreen()},{c.GetByteBlue()})";
-    public static string ToRgbaString( this Color c )       =>  $"RGBA({c.GetByteRed()},{c.GetByteGreen()},{c.GetByteBlue()},{c.Alpha})";
-    public static string ToCmykString( this Color c )       =>  $"CMYK({c.GetPercentCyan():P0},{c.GetPercentMagenta():P0},{c.GetPercentYellow():P0},{c.GetPercentBlackKey():P0})";
-    public static string ToCmykaString( this Color c )      =>  $"CMYKA({c.GetPercentCyan():P0},{c.GetPercentMagenta():P0},{c.GetPercentYellow():P0},{c.GetPercentBlackKey():P0},{c.Alpha})";
-    public static string ToHslString( this Color c )        =>  $"HSL({c.GetDegreeHue():0},{c.GetSaturation():P0},{c.GetLuminosity():P0})";
-    public static string ToHslaString( this Color c )       =>  $"HSLA({c.GetDegreeHue():0},{c.GetSaturation():P0},{c.GetLuminosity():P0},{c.Alpha})";
+    public static string ToHexRgbString(this Color c) => $"#{c.GetByteRed():X2}{c.GetByteGreen():X2}{c.GetByteBlue():X2}";
+    public static string ToHexRgbaString(this Color c) => $"#{c.GetByteRed():X2}{c.GetByteGreen():X2}{c.GetByteBlue():X2}{c.GetByteAlpha():X2}";
+    public static string ToHexArgbString(this Color c) => $"#{c.GetByteAlpha():X2}{c.GetByteRed():X2}{c.GetByteGreen():X2}{c.GetByteBlue():X2}";
+    public static string ToRgbString(this Color c) => $"RGB({c.GetByteRed()},{c.GetByteGreen()},{c.GetByteBlue()})";
+    public static string ToRgbaString(this Color c) => $"RGBA({c.GetByteRed()},{c.GetByteGreen()},{c.GetByteBlue()},{c.Alpha})";
+    public static string ToCmykString(this Color c) => $"CMYK({c.GetPercentCyan():P0},{c.GetPercentMagenta():P0},{c.GetPercentYellow():P0},{c.GetPercentBlackKey():P0})";
+    public static string ToCmykaString(this Color c) => $"CMYKA({c.GetPercentCyan():P0},{c.GetPercentMagenta():P0},{c.GetPercentYellow():P0},{c.GetPercentBlackKey():P0},{c.Alpha})";
+    public static string ToHslString(this Color c) => $"HSL({c.GetDegreeHue():0},{c.GetSaturation():P0},{c.GetLuminosity():P0})";
+    public static string ToHslaString(this Color c) => $"HSLA({c.GetDegreeHue():0},{c.GetSaturation():P0},{c.GetLuminosity():P0},{c.Alpha})";
 
     //  With functions from double
-    public static Color WithRed( this Color baseColor, double newR ) =>
+    public static Color WithRed(this Color baseColor, double newR) =>
         newR < 0 || newR > 1
-            ? throw new ArgumentOutOfRangeException( nameof( newR ) )
-            : Color.FromRgba( newR, baseColor.Green, baseColor.Blue, baseColor.Alpha );
+            ? throw new ArgumentOutOfRangeException(nameof(newR))
+            : Color.FromRgba(newR, baseColor.Green, baseColor.Blue, baseColor.Alpha);
 
-    public static Color WithGreen( this Color baseColor, double newG ) =>
+    public static Color WithGreen(this Color baseColor, double newG) =>
         newG < 0 || newG > 1
-            ? throw new ArgumentOutOfRangeException( nameof( newG ) )
-            : Color.FromRgba( baseColor.Red, newG, baseColor.Blue, baseColor.Alpha );
+            ? throw new ArgumentOutOfRangeException(nameof(newG))
+            : Color.FromRgba(baseColor.Red, newG, baseColor.Blue, baseColor.Alpha);
 
-    public static Color WithBlue( this Color baseColor, double newB ) =>
+    public static Color WithBlue(this Color baseColor, double newB) =>
         newB < 0 || newB > 1
-            ? throw new ArgumentOutOfRangeException( nameof( newB ) )
-            : Color.FromRgba( baseColor.Red, baseColor.Green, newB, baseColor.Alpha );
+            ? throw new ArgumentOutOfRangeException(nameof(newB))
+            : Color.FromRgba(baseColor.Red, baseColor.Green, newB, baseColor.Alpha);
 
     //  With functions from byte
-    public static Color WithRed( this Color baseColor, byte newR )      => Color.FromRgba( (double)newR / 255, baseColor.Green, baseColor.Blue, baseColor.Alpha );
-    public static Color WithGreen( this Color baseColor, byte newG )    => Color.FromRgba( baseColor.Red, (double)newG / 255, baseColor.Blue, baseColor.Alpha );
-    public static Color WithBlue( this Color baseColor, byte newB )     => Color.FromRgba( baseColor.Red, baseColor.Green, (double)newB / 255, baseColor.Alpha );
-    public static Color WithAlpha( this Color baseColor, byte newA )    => Color.FromRgba( baseColor.Red, baseColor.Green, baseColor.Blue, (double)newA / 255 );
+    public static Color WithRed(this Color baseColor, byte newR) => Color.FromRgba((double)newR / 255, baseColor.Green, baseColor.Blue, baseColor.Alpha);
+    public static Color WithGreen(this Color baseColor, byte newG) => Color.FromRgba(baseColor.Red, (double)newG / 255, baseColor.Blue, baseColor.Alpha);
+    public static Color WithBlue(this Color baseColor, byte newB) => Color.FromRgba(baseColor.Red, baseColor.Green, (double)newB / 255, baseColor.Alpha);
+    public static Color WithAlpha(this Color baseColor, byte newA) => Color.FromRgba(baseColor.Red, baseColor.Green, baseColor.Blue, (double)newA / 255);
 
     //  With CMY from double
-    public static Color WithCyan( this Color baseColor, double newC ) =>
-        Color.FromRgba( ( 1 - newC ) * ( 1 - baseColor.GetPercentBlackKey() ),
-                       ( 1 - baseColor.GetPercentMagenta() ) * ( 1 - baseColor.GetPercentBlackKey() ),
-                       ( 1 - baseColor.GetPercentYellow() ) * ( 1 - baseColor.GetPercentBlackKey() ),
-                       baseColor.Alpha );
+    public static Color WithCyan(this Color baseColor, double newC) =>
+        Color.FromRgba((1 - newC) * (1 - baseColor.GetPercentBlackKey()),
+                       (1 - baseColor.GetPercentMagenta()) * (1 - baseColor.GetPercentBlackKey()),
+                       (1 - baseColor.GetPercentYellow()) * (1 - baseColor.GetPercentBlackKey()),
+                       baseColor.Alpha);
 
-    public static Color WithMagenta( this Color baseColor, double newM ) =>
-        Color.FromRgba( ( 1 - baseColor.GetPercentCyan() ) * ( 1 - baseColor.GetPercentBlackKey() ),
-                       ( 1 - newM ) * ( 1 - baseColor.GetPercentBlackKey() ),
-                       ( 1 - baseColor.GetPercentYellow() ) * ( 1 - baseColor.GetPercentBlackKey() ),
-                       baseColor.Alpha );
+    public static Color WithMagenta(this Color baseColor, double newM) =>
+        Color.FromRgba((1 - baseColor.GetPercentCyan()) * (1 - baseColor.GetPercentBlackKey()),
+                       (1 - newM) * (1 - baseColor.GetPercentBlackKey()),
+                       (1 - baseColor.GetPercentYellow()) * (1 - baseColor.GetPercentBlackKey()),
+                       baseColor.Alpha);
 
-    public static Color WithYellow( this Color baseColor, double newY ) =>
-        Color.FromRgba( ( 1 - baseColor.GetPercentCyan() ) * ( 1 - baseColor.GetPercentBlackKey() ),
-                       ( 1 - baseColor.GetPercentMagenta() ) * ( 1 - baseColor.GetPercentBlackKey() ),
-                       ( 1 - newY ) * ( 1 - baseColor.GetPercentBlackKey() ),
-                       baseColor.Alpha );
+    public static Color WithYellow(this Color baseColor, double newY) =>
+        Color.FromRgba((1 - baseColor.GetPercentCyan()) * (1 - baseColor.GetPercentBlackKey()),
+                       (1 - baseColor.GetPercentMagenta()) * (1 - baseColor.GetPercentBlackKey()),
+                       (1 - newY) * (1 - baseColor.GetPercentBlackKey()),
+                       baseColor.Alpha);
 
-    public static Color WithBlackKey( this Color baseColor, double newK ) =>
-        Color.FromRgba( ( 1 - baseColor.GetPercentCyan() ) * ( 1 - newK ),
-                       ( 1 - baseColor.GetPercentMagenta() ) * ( 1 - newK ),
-                       ( 1 - baseColor.GetPercentYellow() ) * ( 1 - newK ),
-                       baseColor.Alpha );
+    public static Color WithBlackKey(this Color baseColor, double newK) =>
+        Color.FromRgba((1 - baseColor.GetPercentCyan()) * (1 - newK),
+                       (1 - baseColor.GetPercentMagenta()) * (1 - newK),
+                       (1 - baseColor.GetPercentYellow()) * (1 - newK),
+                       baseColor.Alpha);
 
     //  Get byte functions
-    public static byte GetByteRed( this Color c )       => ToByte( c.Red * 255 );
-    public static byte GetByteGreen( this Color c )     => ToByte( c.Green * 255 );
-    public static byte GetByteBlue( this Color c )      => ToByte( c.Blue * 255 );
-    public static byte GetByteAlpha( this Color c )     => ToByte( c.Alpha * 255 );
+    public static byte GetByteRed(this Color c) => ToByte(c.Red * 255);
+    public static byte GetByteGreen(this Color c) => ToByte(c.Green * 255);
+    public static byte GetByteBlue(this Color c) => ToByte(c.Blue * 255);
+    public static byte GetByteAlpha(this Color c) => ToByte(c.Alpha * 255);
 
     //  Get Degree of Hue
-    public static double GetDegreeHue( this Color c )   => c.GetHue() * 360;
+    public static double GetDegreeHue(this Color c) => c.GetHue() * 360;
 
     //  Get Percent functions
-    public static float GetPercentBlackKey( this Color c ) => 1 - Math.Max( Math.Max( c.Red, c.Green ), c.Blue );
+    public static float GetPercentBlackKey(this Color c) => 1 - Math.Max(Math.Max(c.Red, c.Green), c.Blue);
 
-    public static float GetPercentCyan( this Color c ) =>
-        ( 1 - c.GetPercentBlackKey() == 0 ) ? 0 :
-        ( 1 - c.Red - c.GetPercentBlackKey() ) / ( 1 - c.GetPercentBlackKey() );
+    public static float GetPercentCyan(this Color c) =>
+        (1 - c.GetPercentBlackKey() == 0) ? 0 :
+        (1 - c.Red - c.GetPercentBlackKey()) / (1 - c.GetPercentBlackKey());
 
-    public static float GetPercentMagenta( this Color c ) =>
-        ( 1 - c.GetPercentBlackKey() == 0 ) ? 0 :
-        ( 1 - c.Green - c.GetPercentBlackKey() ) / ( 1 - c.GetPercentBlackKey() );
+    public static float GetPercentMagenta(this Color c) =>
+        (1 - c.GetPercentBlackKey() == 0) ? 0 :
+        (1 - c.Green - c.GetPercentBlackKey()) / (1 - c.GetPercentBlackKey());
 
-    public static float GetPercentYellow( this Color c ) =>
-        ( 1 - c.GetPercentBlackKey() == 0 ) ? 0 :
-        ( 1 - c.Blue - c.GetPercentBlackKey() ) / ( 1 - c.GetPercentBlackKey() );
+    public static float GetPercentYellow(this Color c) =>
+        (1 - c.GetPercentBlackKey() == 0) ? 0 :
+        (1 - c.Blue - c.GetPercentBlackKey()) / (1 - c.GetPercentBlackKey());
 
     //  Invert color
-    public static Color ToInverseColor( this Color baseColor ) =>
-        Color.FromRgb( 1 - baseColor.Red, 1 - baseColor.Green, 1 - baseColor.Blue );
+    public static Color ToInverseColor(this Color baseColor) =>
+        Color.FromRgb(1 - baseColor.Red, 1 - baseColor.Green, 1 - baseColor.Blue);
 
     //  To black and white or grayscale
-    public static Color ToBlackOrWhite( this Color baseColor )          => baseColor.IsDark() ? Colors.Black : Colors.White;
-    public static Color ToBlackOrWhiteToForText( this Color baseColor ) =>  baseColor.IsDarkToTheEye() ? Colors.White : Colors.Black;
+    public static Color ToBlackOrWhite(this Color baseColor) => baseColor.IsDark() ? Colors.Black : Colors.White;
+    public static Color ToBlackOrWhiteToForText(this Color baseColor) => baseColor.IsDarkToTheEye() ? Colors.White : Colors.Black;
 
-    public static Color ToGrayScale( this Color baseColor )
+    public static Color ToGrayScale(this Color baseColor)
     {
         var avg = (baseColor.Red + baseColor.Blue + baseColor.Green) / 3;
-        return Color.FromRgb( avg, avg, avg );
+        return Color.FromRgb(avg, avg, avg);
     }
 
     //  Is dark or perceived as dark
-    public static bool IsDark( this Color c ) => c.GetByteRed() + c.GetByteGreen() + c.GetByteBlue() <= 127 * 3;
+    public static bool IsDark(this Color c) => c.GetByteRed() + c.GetByteGreen() + c.GetByteBlue() <= 127 * 3;
 
-    public static bool IsDarkToTheEye( this Color c ) =>
-        ( c.GetByteRed() * 0.299 ) + ( c.GetByteGreen() * 0.587 ) + ( c.GetByteBlue() * 0.114 ) <= 186;
+    public static bool IsDarkToTheEye(this Color c) =>
+        (c.GetByteRed() * 0.299) + (c.GetByteGreen() * 0.587) + (c.GetByteBlue() * 0.114) <= 186;
 
     //  Convert double to byte
-    static byte ToByte( double input )
-            =>  input < 0 ? (byte)0 
-                          : input > 255 ? (byte)255 
-                                        : (byte)Math.Round( input );
+    static byte ToByte(double input)
+            => input < 0 ? (byte)0
+                          : input > 255 ? (byte)255
+                                        : (byte)Math.Round(input);
 }

--- a/ColorPickerTestApp/Converters/ColorToHSLAConverter.cs
+++ b/ColorPickerTestApp/Converters/ColorToHSLAConverter.cs
@@ -2,14 +2,14 @@
 
 using static ColorConverterExtensions;
 
-public class ColorToHSLAStringConverter: IValueConverter
-{ 
-    public object Convert( object value, Type targetType, object parameter, CultureInfo culture )
+public class ColorToHSLAStringConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
-        if ( value is not Color color )
-            throw new InvalidDataException( "Source is not a Color" );
+        if (value is not Color color)
+            throw new InvalidDataException("Source is not a Color");
 
-        return (string) color.ToHslaString();
+        return (string)color.ToHslaString();
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/ColorPickerTestApp/Converters/ColorToHexStringConverter.cs
+++ b/ColorPickerTestApp/Converters/ColorToHexStringConverter.cs
@@ -4,12 +4,12 @@ using static ColorConverterExtensions;
 
 public class ColorToHexStringConverter : IValueConverter
 {
-    public object Convert( object value, Type targetType, object parameter, CultureInfo culture )
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
-        if ( value is not Color color )
-            throw new InvalidDataException( "Source is not a Color" );
+        if (value is not Color color)
+            throw new InvalidDataException("Source is not a Color");
 
-        return (string) color.ToHexRgbaString();
+        return (string)color.ToHexRgbaString();
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/ColorPickerTestApp/Converters/ColorToRGBAStringConverter.cs
+++ b/ColorPickerTestApp/Converters/ColorToRGBAStringConverter.cs
@@ -4,12 +4,12 @@ using static ColorConverterExtensions;
 
 public class ColorToRGBAStringConverter : IValueConverter
 {
-    public object Convert( object value, Type targetType, object parameter, CultureInfo culture )
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
-        if ( value is not Color color )
-            throw new InvalidDataException( "Source is not a Color" );
+        if (value is not Color color)
+            throw new InvalidDataException("Source is not a Color");
 
-        return (string) color.ToRgbaString();
+        return (string)color.ToRgbaString();
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/ColorPickerTestApp/Converters/InverseBoolConverter.cs
+++ b/ColorPickerTestApp/Converters/InverseBoolConverter.cs
@@ -2,6 +2,6 @@
 
 public class InverseBoolConverter : IValueConverter
 {
-    public object Convert( object value, Type targetType, object parameter, CultureInfo culture )   =>  ! (bool)value ;
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>  value;
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => !(bool)value;
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => value;
 }

--- a/ColorPickerTestApp/LayoutTestPage.xaml.cs
+++ b/ColorPickerTestApp/LayoutTestPage.xaml.cs
@@ -147,15 +147,15 @@ public partial class LayoutTestPage : ContentPage
         switch (wMode)
         {
             case SizeMode.Fixed:
-                HostBorder.WidthRequest      = wValue;
+                HostBorder.WidthRequest = wValue;
                 HostBorder.HorizontalOptions = LayoutOptions.Start;
                 break;
             case SizeMode.Auto:
-                HostBorder.WidthRequest      = -1;
+                HostBorder.WidthRequest = -1;
                 HostBorder.HorizontalOptions = LayoutOptions.Start;
                 break;
             case SizeMode.Fill:
-                HostBorder.WidthRequest      = -1;
+                HostBorder.WidthRequest = -1;
                 HostBorder.HorizontalOptions = LayoutOptions.Fill;
                 break;
         }
@@ -163,16 +163,16 @@ public partial class LayoutTestPage : ContentPage
         switch (hMode)
         {
             case SizeMode.Fixed:
-                HostBorder.HeightRequest    = hValue;
-                HostBorder.VerticalOptions  = LayoutOptions.Start;
+                HostBorder.HeightRequest = hValue;
+                HostBorder.VerticalOptions = LayoutOptions.Start;
                 break;
             case SizeMode.Auto:
-                HostBorder.HeightRequest    = -1;
-                HostBorder.VerticalOptions  = LayoutOptions.Start;
+                HostBorder.HeightRequest = -1;
+                HostBorder.VerticalOptions = LayoutOptions.Start;
                 break;
             case SizeMode.Fill:
-                HostBorder.HeightRequest    = -1;
-                HostBorder.VerticalOptions  = LayoutOptions.Fill;
+                HostBorder.HeightRequest = -1;
+                HostBorder.VerticalOptions = LayoutOptions.Fill;
                 break;
         }
     }
@@ -185,12 +185,12 @@ public partial class LayoutTestPage : ContentPage
         // The trailing "desired=" segment carries the inner control's
         // measured DesiredSize so tests can detect MeasureOverride regressions
         // even when the parent host clamps the arranged bounds.
-        var hX = HostBorder.X;       var hY = HostBorder.Y;
-        var hW = HostBorder.Width;   var hH = HostBorder.Height;
-        var cX = ScenarioContent.X;  var cY = ScenarioContent.Y;
+        var hX = HostBorder.X; var hY = HostBorder.Y;
+        var hW = HostBorder.Width; var hH = HostBorder.Height;
+        var cX = ScenarioContent.X; var cY = ScenarioContent.Y;
         var cW = ScenarioContent.Width; var cH = ScenarioContent.Height;
-        var vX = HostContainer.X;    var vY = HostContainer.Y;
-        var vW = HostContainer.Width;var vH = HostContainer.Height;
+        var vX = HostContainer.X; var vY = HostContainer.Y;
+        var vW = HostContainer.Width; var vH = HostContainer.Height;
         double dW = 0, dH = 0;
         if (ScenarioContent.Content is View innerCtrl)
         {
@@ -320,14 +320,14 @@ public partial class LayoutTestPage : ContentPage
             T($"CONTENT-SET; hb.W={HostBorder.Width:0} hb.H={HostBorder.Height:0} sc.W={ScenarioContent.Width:0} sc.H={ScenarioContent.Height:0}");
             _lastControl = control; _lastSizeKey = sizeKey; _lastFeatureKey = featureKey;
 
-            StatusLabel.Text  = $"applied: {spec}";
+            StatusLabel.Text = $"applied: {spec}";
             UpdateAppliedMarker();
             T($"DONE marker={AppliedLabel.Text}");
         }
         catch (Exception ex)
         {
             T($"EXCEPTION:{ex.GetType().Name}:{ex.Message}");
-            StatusLabel.Text  = "error: " + ex.Message;
+            StatusLabel.Text = "error: " + ex.Message;
             AppliedLabel.Text = "ERROR:" + ex.Message;
         }
     }
@@ -337,22 +337,22 @@ public partial class LayoutTestPage : ContentPage
         if (control == "wheel" && existing is ColorWheel w)
         {
             // Reset to defaults then apply opts.
-            w.ShowAlphaSlider     = false;
-            w.ShowLuminositySlider= false;
+            w.ShowAlphaSlider = false;
+            w.ShowLuminositySlider = false;
             w.ShowLuminosityRing = true;
-            w.Vertical            = false;
+            w.Vertical = false;
             w.CanvasBackgroundColor = Colors.Transparent;
             foreach (var opt in opts)
             {
                 if (IsKvOpt(opt, out _, out _)) continue; // handled separately
                 switch (opt.Trim().ToLowerInvariant())
                 {
-                    case "alpha":     w.ShowAlphaSlider     = true;  break;
-                    case "lumslider": w.ShowLuminositySlider= true;  break;
-                    case "nolumwheel":w.ShowLuminosityRing = false; break;
-                    case "vertical":  w.Vertical            = true;  break;
-                    case "":          break;
-                    default:          throw new ArgumentException("Unknown option: " + opt);
+                    case "alpha": w.ShowAlphaSlider = true; break;
+                    case "lumslider": w.ShowLuminositySlider = true; break;
+                    case "nolumwheel": w.ShowLuminosityRing = false; break;
+                    case "vertical": w.Vertical = true; break;
+                    case "": break;
+                    default: throw new ArgumentException("Unknown option: " + opt);
                 }
             }
             var wbg = ParseColorOpt(opts, "wbg");
@@ -362,23 +362,23 @@ public partial class LayoutTestPage : ContentPage
         if (control == "triangle" && existing is ColorTriangle t)
         {
             t.CanvasBackgroundColor = ParseColorOpt(opts, "wbg") ?? Colors.Transparent;
-            t.RotateTriangleByHue  = true;
+            t.RotateTriangleByHue = true;
             foreach (var opt in opts)
             {
                 if (IsKvOpt(opt, out _, out _)) continue;
                 switch (opt.Trim().ToLowerInvariant())
                 {
                     case "norotate": t.RotateTriangleByHue = false; break;
-                    case "rotate":   t.RotateTriangleByHue = true;  break;
-                    case "":         break;
-                    default:         throw new ArgumentException("Unknown option: " + opt);
+                    case "rotate": t.RotateTriangleByHue = true; break;
+                    case "": break;
+                    default: throw new ArgumentException("Unknown option: " + opt);
                 }
             }
             return true;
         }
         if ((control == "hsl" || control == "rgb") && existing is SliderStackWithAlpha s)
         {
-            s.Vertical        = false;
+            s.Vertical = false;
             s.ShowAlphaSlider = true;
             s.IndicatorRadiusScale = 0F;
             foreach (var opt in opts)
@@ -386,10 +386,10 @@ public partial class LayoutTestPage : ContentPage
                 if (IsKvOpt(opt, out _, out _)) continue;
                 switch (opt.Trim().ToLowerInvariant())
                 {
-                    case "vertical": s.Vertical        = true;  break;
-                    case "noalpha":  s.ShowAlphaSlider = false; break;
-                    case "":         break;
-                    default:         throw new ArgumentException("Unknown option: " + opt);
+                    case "vertical": s.Vertical = true; break;
+                    case "noalpha": s.ShowAlphaSlider = false; break;
+                    case "": break;
+                    default: throw new ArgumentException("Unknown option: " + opt);
                 }
             }
             var prs = ParseFloatOpt(opts, "prs");
@@ -409,10 +409,10 @@ public partial class LayoutTestPage : ContentPage
             if (IsKvOpt(opt, out _, out _)) continue;
             switch (opt.Trim().ToLowerInvariant())
             {
-                case "vertical": s.Vertical        = true;  break;
-                case "noalpha":  s.ShowAlphaSlider = false; break;
-                case "":         break;
-                default:         throw new ArgumentException("Unknown option: " + opt);
+                case "vertical": s.Vertical = true; break;
+                case "noalpha": s.ShowAlphaSlider = false; break;
+                case "": break;
+                default: throw new ArgumentException("Unknown option: " + opt);
             }
         }
         var prs = ParseFloatOpt(opts, "prs");
@@ -428,13 +428,13 @@ public partial class LayoutTestPage : ContentPage
             if (IsKvOpt(opt, out _, out _)) continue;
             switch (opt.Trim().ToLowerInvariant())
             {
-                case "alpha":     wheel.ShowAlphaSlider     = true;  break;
+                case "alpha": wheel.ShowAlphaSlider = true; break;
                 case "lumslider": wheel.ShowLuminositySlider = true; break;
                 case "noLumWheel":
-                case "nolumwheel":wheel.ShowLuminosityRing  = false; break;
-                case "vertical":  wheel.Vertical            = true;  break;
-                case "":          break;
-                default:          throw new ArgumentException("Unknown option: " + opt);
+                case "nolumwheel": wheel.ShowLuminosityRing = false; break;
+                case "vertical": wheel.Vertical = true; break;
+                case "": break;
+                default: throw new ArgumentException("Unknown option: " + opt);
             }
         }
         var wbg = ParseColorOpt(opts, "wbg");
@@ -450,9 +450,9 @@ public partial class LayoutTestPage : ContentPage
             switch (opt.Trim().ToLowerInvariant())
             {
                 case "norotate": t.RotateTriangleByHue = false; break;
-                case "rotate":   t.RotateTriangleByHue = true;  break;
-                case "":         break;
-                default:         throw new ArgumentException("Unknown option: " + opt);
+                case "rotate": t.RotateTriangleByHue = true; break;
+                case "": break;
+                default: throw new ArgumentException("Unknown option: " + opt);
             }
         }
         var wbg = ParseColorOpt(opts, "wbg");
@@ -465,7 +465,7 @@ public partial class LayoutTestPage : ContentPage
         var idx = opt.IndexOf('=');
         if (idx > 0)
         {
-            key   = opt[..idx].Trim().ToLowerInvariant();
+            key = opt[..idx].Trim().ToLowerInvariant();
             value = opt[(idx + 1)..].Trim();
             return true;
         }
@@ -503,15 +503,15 @@ public partial class LayoutTestPage : ContentPage
         if (s.StartsWith("#")) return Color.FromArgb(s);
         return s.ToLowerInvariant() switch
         {
-            "transparent"  => Colors.Transparent,
-            "white"        => Colors.White,
-            "black"        => Colors.Black,
-            "red"          => Colors.Red,
-            "green"        => Colors.Green,
-            "blue"         => Colors.Blue,
-            "yellow"       => Colors.Yellow,
-            "magenta"      => Colors.Magenta,
-            "cyan"         => Colors.Cyan,
+            "transparent" => Colors.Transparent,
+            "white" => Colors.White,
+            "black" => Colors.Black,
+            "red" => Colors.Red,
+            "green" => Colors.Green,
+            "blue" => Colors.Blue,
+            "yellow" => Colors.Yellow,
+            "magenta" => Colors.Magenta,
+            "cyan" => Colors.Cyan,
             "gray" or "grey" => Colors.Gray,
             "lightgray" or "lightgrey" => Colors.LightGray,
             _ => throw new ArgumentException("Unknown color: " + s),

--- a/ColorPickerTestApp/MainPage.xaml.cs
+++ b/ColorPickerTestApp/MainPage.xaml.cs
@@ -1,14 +1,14 @@
-﻿namespace ColorPickerTestApp;
+namespace ColorPickerTestApp;
 
 public partial class MainPage : ContentPage
 {
     public MainPage() => InitializeComponent();
 
-    void OnPaintSurface( object sender, SKPaintSurfaceEventArgs e )
+    void OnPaintSurface(object sender, SKPaintSurfaceEventArgs e)
     {
-        if ( sender is not SKCanvasView canvasView )
+        if (sender is not SKCanvasView canvasView)
         {
-            throw new InvalidOperationException( "Not a SKCanvasView" );
+            throw new InvalidOperationException("Not a SKCanvasView");
         }
 
         var scale       = 21F;
@@ -16,29 +16,29 @@ public partial class MainPage : ContentPage
         var canvas = e.Surface.Canvas;
         SKPath path     = new();
 
-        path.MoveTo( -1 * scale, -1 * scale );
-        path.LineTo(  0 * scale, -1 * scale );
-        path.LineTo(  0 * scale,  0 * scale );
-        path.LineTo(  1 * scale,  0 * scale );
-        path.LineTo(  1 * scale,  1 * scale );
-        path.LineTo(  0 * scale,  1 * scale );
-        path.LineTo(  0 * scale,  0 * scale );
-        path.LineTo( -1 * scale,  0 * scale );
-        path.LineTo( -1 * scale, -1 * scale );
+        path.MoveTo(-1 * scale, -1 * scale);
+        path.LineTo(0 * scale, -1 * scale);
+        path.LineTo(0 * scale, 0 * scale);
+        path.LineTo(1 * scale, 0 * scale);
+        path.LineTo(1 * scale, 1 * scale);
+        path.LineTo(0 * scale, 1 * scale);
+        path.LineTo(0 * scale, 0 * scale);
+        path.LineTo(-1 * scale, 0 * scale);
+        path.LineTo(-1 * scale, -1 * scale);
 
-        var matrix = SKMatrix.CreateScale( 2 * scale, 2 * scale );
+        var matrix = SKMatrix.CreateScale(2 * scale, 2 * scale);
 
         SKPaint paint = new()
         {
-            PathEffect  = SKPathEffect.Create2DPath( matrix, path ),
+            PathEffect  = SKPathEffect.Create2DPath(matrix, path),
             Color       = Colors.LightSkyBlue.ToSKColor(),
             IsAntialias = true
         };
 
-        var patternRect = new SKRect( 0, 0, canvasView.CanvasSize.Width, canvasView.CanvasSize.Height );
+        var patternRect = new SKRect(0, 0, canvasView.CanvasSize.Width, canvasView.CanvasSize.Height);
 
         canvas.Save();
-        canvas.DrawRect( patternRect, paint );
+        canvas.DrawRect(patternRect, paint);
         canvas.Restore();
     }
 }

--- a/ColorPickerTestApp/MauiProgram.cs
+++ b/ColorPickerTestApp/MauiProgram.cs
@@ -21,7 +21,7 @@ public static class MauiProgram
         //
         builder.UseColorPickersAndSliders();
 
-        builder.ConfigureFonts( fonts => fonts.AddFont( "OpenSans-Regular.ttf", "OpenSansRegular" ) );
+        builder.ConfigureFonts(fonts => fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular"));
 
         return builder.Build();
     }

--- a/ColorPickerTestApp/Platforms/Android/MainActivity.cs
+++ b/ColorPickerTestApp/Platforms/Android/MainActivity.cs
@@ -4,25 +4,25 @@ using Android.App;
 using Android.Content.PM;
 using Android.OS;
 
-[Activity( Theme        = "@style/Maui.SplashTheme", 
+[Activity(Theme = "@style/Maui.SplashTheme",
            MainLauncher = true,
-           ConfigurationChanges = ConfigChanges.ScreenSize   |
-                                  ConfigChanges.Orientation  | 
-                                  ConfigChanges.UiMode       |
-                                  ConfigChanges.ScreenLayout | 
-                                  ConfigChanges.SmallestScreenSize )]
+           ConfigurationChanges = ConfigChanges.ScreenSize |
+                                  ConfigChanges.Orientation |
+                                  ConfigChanges.UiMode |
+                                  ConfigChanges.ScreenLayout |
+                                  ConfigChanges.SmallestScreenSize)]
 public class MainActivity : MauiAppCompatActivity
 {
-    protected override void OnCreate( Bundle savedInstanceState )
+    protected override void OnCreate(Bundle savedInstanceState)
     {
-        base.OnCreate( savedInstanceState );
-        Platform.Init( this, savedInstanceState );
+        base.OnCreate(savedInstanceState);
+        Platform.Init(this, savedInstanceState);
     }
 
-    public override void OnRequestPermissionsResult( int requestCode, string[] permissions, Permission[] grantResults )
+    public override void OnRequestPermissionsResult(int requestCode, string[] permissions, Permission[] grantResults)
     {
-        Platform.OnRequestPermissionsResult( requestCode, permissions, grantResults );
+        Platform.OnRequestPermissionsResult(requestCode, permissions, grantResults);
 
-        base.OnRequestPermissionsResult( requestCode, permissions, grantResults );
+        base.OnRequestPermissionsResult(requestCode, permissions, grantResults);
     }
 }

--- a/ColorPickerTestApp/Platforms/Android/MainApplication.cs
+++ b/ColorPickerTestApp/Platforms/Android/MainApplication.cs
@@ -6,10 +6,10 @@ using Android.Runtime;
 [Application]
 public class MainApplication : MauiApplication
 {
-	public MainApplication(IntPtr handle, JniHandleOwnership ownership)
-		: base(handle, ownership)
-	{
-	}
+    public MainApplication(IntPtr handle, JniHandleOwnership ownership)
+        : base(handle, ownership)
+    {
+    }
 
-	protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
 }


### PR DESCRIPTION
Drops the project's old non-mainstream formatting choices (inherited from an earlier collaborator) and reformats the entire codebase to match modern Microsoft / Roslyn defaults.

## .editorconfig changes

| Setting | Old | New | Effect |
|---|---|---|---|
| `csharp_space_between_method_call_parameter_list_parentheses` | true | false | `Foo(x, y)` |
| `csharp_space_between_method_declaration_parameter_list_parentheses` | true | false | `void Foo(int x)` |
| `csharp_space_between_parentheses` | control_flow_statements,expressions | (none) | `if (cond)`, `(a + b)` |
| `csharp_space_between_square_brackets` | true | false | `arr[i]` |
| `csharp_using_directive_placement` | inside_namespace | outside_namespace | `using` at top of file |
| `dotnet_separate_import_directive_groups` | true | false | no blank line between using groups |
| `csharp_indent_labels` | flush_left | one_less_than_current | Roslyn default |
| `csharp_style_allow_embedded_statements_on_same_line_experimental` | true | false | `if (x) return;` discouraged |

## How

1. Edited `.editorconfig` in place
2. `dotnet format` on each csproj (caught single-line cases)
3. Targeted regex pass for multi-line method calls (`( ` -> `(`, ` )` -> `)`, same for square brackets), which `dotnet format` does not currently rewrite

## Scope

58 files, ~1215 / 1214 lines (pure whitespace, equal in/out). No behavior change.

## Validation

- `ColorPicker` builds clean, 0 warnings, 0 errors
- `ColorPickerTestApp` builds clean (pre-existing 40 warnings unchanged)
- String literals audited — no text content modified, only code expressions inside interpolations got the standard `,_` -> `, _` treatment that `dotnet format` applies

CI will validate via the 213-test UI suite + Consumer Smoke.

🟡 **Not for auto-merge.** Waiting on owner review.