### PR TITLE
chore: clean up all build warnings

### DIFF
--- a/ColorPicker.UITests/Tests/VisualProbe.cs
+++ b/ColorPicker.UITests/Tests/VisualProbe.cs
@@ -24,13 +24,6 @@ public class VisualProbe
 
     public static IEnumerable<object[]> AllScenarios()
     {
-        var seen = new HashSet<string>();
-        void Add(string id, string spec)
-        {
-            if (seen.Add(spec)) {/*ok*/}
-            else id += "-dup";
-            // we still emit duplicates with -dup suffix so the manifest is complete.
-        }
         var list = new List<(string id, string spec)>();
         void Emit(string id, string spec)
         {

--- a/ColorPickerTestApp/Converters/BoolToSwitchConverter.cs
+++ b/ColorPickerTestApp/Converters/BoolToSwitchConverter.cs
@@ -4,9 +4,9 @@ using System.Globalization;
 
 public class BoolToSwitchConverter : IValueConverter
 {
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-            => (bool)value ? "Show Wheel" : "Show Triangle";
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+            => (bool)value! ? "Show Wheel" : "Show Triangle";
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-            => (string)value == "Show Wheel";
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+            => (string)value! == "Show Wheel";
 }

--- a/ColorPickerTestApp/Converters/ColorToHSLAConverter.cs
+++ b/ColorPickerTestApp/Converters/ColorToHSLAConverter.cs
@@ -4,7 +4,7 @@ using static ColorConverterExtensions;
 
 public class ColorToHSLAStringConverter : IValueConverter
 {
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is not Color color)
             throw new InvalidDataException("Source is not a Color");
@@ -12,6 +12,6 @@ public class ColorToHSLAStringConverter : IValueConverter
         return (string)color.ToHslaString();
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
             => throw new NotImplementedException();
 }

--- a/ColorPickerTestApp/Converters/ColorToHexStringConverter.cs
+++ b/ColorPickerTestApp/Converters/ColorToHexStringConverter.cs
@@ -4,7 +4,7 @@ using static ColorConverterExtensions;
 
 public class ColorToHexStringConverter : IValueConverter
 {
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is not Color color)
             throw new InvalidDataException("Source is not a Color");
@@ -12,6 +12,6 @@ public class ColorToHexStringConverter : IValueConverter
         return (string)color.ToHexRgbaString();
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
             => throw new NotImplementedException();
 }

--- a/ColorPickerTestApp/Converters/ColorToRGBAStringConverter.cs
+++ b/ColorPickerTestApp/Converters/ColorToRGBAStringConverter.cs
@@ -4,7 +4,7 @@ using static ColorConverterExtensions;
 
 public class ColorToRGBAStringConverter : IValueConverter
 {
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is not Color color)
             throw new InvalidDataException("Source is not a Color");
@@ -12,6 +12,6 @@ public class ColorToRGBAStringConverter : IValueConverter
         return (string)color.ToRgbaString();
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
             => throw new NotImplementedException();
 }

--- a/ColorPickerTestApp/Converters/InverseBoolConverter.cs
+++ b/ColorPickerTestApp/Converters/InverseBoolConverter.cs
@@ -2,6 +2,6 @@
 
 public class InverseBoolConverter : IValueConverter
 {
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => !(bool)value;
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => value;
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => !(bool)value!;
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => value;
 }

--- a/ColorPickerTestApp/LayoutTestPage.xaml.cs
+++ b/ColorPickerTestApp/LayoutTestPage.xaml.cs
@@ -241,16 +241,13 @@ public partial class LayoutTestPage : ContentPage
         catch (Exception ex) { DebugTraceLabel.Text = "diag err: " + ex.Message; }
     }
 
-    /// <summary>
-    /// Scenario format: "<control>:<width>x<height>[:opt1,opt2,...]"
-    ///   control = wheel | triangle | hsl | rgb
-    ///   opts (wheel only): alpha, lumslider, lumwheel, vertical
-    /// Examples:
-    ///   "wheel:300x300"
-    ///   "wheel:400x400:alpha,vertical"
-    ///   "triangle:600x300"
-    /// </summary>
     /// <summary>How a single dimension is sized.</summary>
+    /// <remarks>
+    /// Scenario format: <c>&lt;control&gt;:&lt;width&gt;x&lt;height&gt;[:opt1,opt2,...]</c>.
+    /// control = wheel | triangle | hsl | rgb.
+    /// opts (wheel only): alpha, lumslider, lumwheel, vertical.
+    /// Examples: <c>wheel:300x300</c>, <c>wheel:400x400:alpha,vertical</c>, <c>triangle:600x300</c>.
+    /// </remarks>
     enum SizeMode { Fixed, Auto, Fill }
 
     void ApplyScenario(string spec)

--- a/ColorPickerTestApp/Platforms/Android/MainActivity.cs
+++ b/ColorPickerTestApp/Platforms/Android/MainActivity.cs
@@ -13,7 +13,7 @@ using Android.OS;
                                   ConfigChanges.SmallestScreenSize)]
 public class MainActivity : MauiAppCompatActivity
 {
-    protected override void OnCreate(Bundle savedInstanceState)
+    protected override void OnCreate(Bundle? savedInstanceState)
     {
         base.OnCreate(savedInstanceState);
         Platform.Init(this, savedInstanceState);


### PR DESCRIPTION
Clears every build warning across the repo.

## Before
| Project | Warnings |
|---|---:|
| ColorPicker (library) | 0 |
| ColorPickerTestApp | **56** (all CS8767) |
| ColorPicker.UITests | **1** (CS8321) |

Plus one broken XML doc comment in LayoutTestPage.xaml.cs that was tripping XML-doc validation in Android CI (visible as 4 annotations on PR #21).

## Fixes
- **5 IValueConverter implementations** in ColorPickerTestApp/Converters: changed signatures from \object Convert(object value, ..., object parameter, ...)\ to \object? Convert(object? value, ..., object? parameter, ...)\ to match the interface. Added \!\ on the cast sites where the implementation already assumed non-null (existing behavior preserved).
- **LayoutTestPage.xaml.cs** doc comment: escaped \<\ / \>\ in the format string and dropped the duplicate \<summary>\ block (was \<summary>scenario format with <control>...</summary>\ + \<summary>How a single dimension is sized.</summary>\ for one enum). Now one \<summary>\ + a \<remarks>\.
- **VisualProbe.cs**: removed the unused \Add\ local function and its \seen\ HashSet. \Emit\ is the live path.

## After
\\\
ColorPicker:          0 Warning(s), 0 Error(s)
ColorPickerTestApp:   0 Warning(s), 0 Error(s)
ColorPicker.UITests:  0 Warning(s), 0 Error(s)
\\\

No behavior change. Will let CI run the 213 UI tests to confirm.