### PR TITLE
docs: add AGENTS.md with practical notes for Copilot/agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,124 @@
+# Agent instructions for ColorPicker.Maui
+
+Practical notes accumulated from prior coding sessions. Read before working in this repo to skip re-discovering the quirks.
+
+## Repository layout
+
+| Path | Purpose |
+|---|---|
+| `ColorPicker/` | The library — the published NuGet package (`ColorPicker.Maui`) |
+| `ColorPickerTestApp/` | MAUI app for manual visual testing |
+| `ColorPicker.UITests/` | Appium-driven xUnit UI test suite (~213 tests) |
+| `samples/ConsumerSmoke/` | Smoke project that consumes the **packed nupkg**, *not* a ProjectReference |
+
+## Target frameworks
+
+- Library: `net8.0`, `net8.0-android34.0`, `net8.0-windows10.0.19041.0`
+- Test app: same three TFMs
+
+## Build
+
+Quick local build (Windows TFM only):
+```powershell
+dotnet build ColorPicker\ColorPicker.csproj -c Release -f net8.0-windows10.0.19041.0
+```
+
+**Important:** Some warnings only surface on the **Android** TFM (e.g. `CS8765` on `MainActivity.OnCreate(Bundle savedInstanceState)`). Always check Android too if you're hunting warnings:
+```powershell
+dotnet build ColorPicker\ColorPicker.csproj -c Release -f net8.0-android34.0
+```
+…or rely on CI's "Build Android" job to surface them.
+
+### ConsumerSmoke pitfall
+
+`samples/ConsumerSmoke/ConsumerSmoke.csproj` references the library via **PackageReference** to the locally packed nupkg, not a ProjectReference. Building it from the solution will fail locally with bogus `CS0234: 'Classes'/'Controls' does not exist in namespace 'ColorPicker'` errors — **ignore those**. Only the CI "Consumer Smoke" job builds it correctly (after Pack NuGet produces the nupkg).
+
+## Tests
+
+UI tests run on Windows via Appium. ~12 minutes for the full 213-test suite.
+
+```powershell
+dotnet test ColorPicker.UITests\ColorPicker.UITests.csproj
+```
+
+Appium server must be running; CI sets it up via a workflow step.
+
+## CI pipeline
+
+Every PR runs 5 checks (workflow `.github/workflows/build-and-test.yml`):
+
+1. Build Android (~3 min)
+2. Build Windows (~3 min)
+3. UI Tests (Windows) (~12 min) — the long one
+4. Pack NuGet (~2 min)
+5. Consumer Smoke (~2 min) — depends on Pack NuGet
+
+Expect ~12-13 minutes for full green.
+
+## Branch protection / merging
+
+**There is no branch protection.** Auto-merge does *not* work in this repo — it stays pending forever. Use admin merge for everything:
+
+```bash
+gh pr merge N --admin --squash --delete-branch
+```
+
+Squash merges are the convention here.
+
+## Formatting & style
+
+- Style is mainstream .NET (Microsoft / Roslyn defaults). See `.editorconfig`.
+- File-scoped namespaces everywhere: `namespace Foo;`
+- No spaces inside parens/brackets: `Foo(x, y)`, `arr[i]`, `if (cond)`
+- `using` directives go **outside** the namespace, no separated import groups
+
+Run the formatter:
+```powershell
+dotnet format ColorPicker\ColorPicker.csproj
+```
+
+**Limitation:** `dotnet format whitespace` only fixes **single-line** paren/bracket spacing. Multi-line method calls like:
+
+```csharp
+new Foo( a,
+         b )
+```
+
+…will not be touched. For broad cleanup, a regex pass is needed:
+
+```powershell
+git ls-files '*.cs' | ForEach-Object {
+  $t = Get-Content $_ -Raw
+  $t = $t -replace '\( (?=\S)', '('
+  $t = $t -replace '(?<=\S) \)', ')'
+  $t = $t -replace '\[ (?=\S)', '['
+  $t = $t -replace '(?<=\S) \]', ']'
+  Set-Content $_ -Value $t -NoNewline
+}
+```
+
+The `\S` lookarounds keep empty `()` / `[]` intact and don't touch existing tight pairs.
+
+## Imaging
+
+Uses **SkiaSharp**, not ImageSharp (replaced in checkpoint 038). When working with bitmap rendering or tests that capture pixels, reach for `SKBitmap` / `SKSurface`, not `Image<Rgba32>`.
+
+## Common warning fixes
+
+- **CS8767** (Nullability mismatch on `IValueConverter` implementations): change `object` → `object?` on `value`, `parameter`, and the return type. Keep `Type targetType` and `CultureInfo culture` non-nullable. Add `!` on the cast sites if existing code already assumed non-null.
+- **CS8765** in `MainActivity.OnCreate(Bundle savedInstanceState)`: change to `Bundle? savedInstanceState`. Android-only.
+- **XML doc comment errors** (`Expected end tag…`): escape `<` / `>` in doc strings — use `&lt;` / `&gt;` or wrap in `<c>…</c>`.
+
+## Conventions in the test suite
+
+- **Tier-named test groups** (Tier 1 = LayoutSmoke, Tier 2 = feature matrix, Tier 3 = pixel-diff, Tier 4 = container sizing, etc.).
+- xUnit, not NUnit.
+- Page Object pattern under `ColorPicker.UITests/PageObjects/`.
+- `VisualProbe` is a developer-only scenario dumper, gated on `PROBE_OUT` env var so it doesn't run in CI.
+
+## Where things live
+
+- `ColorPicker/BaseClasses/` — `ColorPickerBase`, `SkiaPickerBase`, `SliderBase`, `SliderStack`, `SliderStackWithAlpha`
+- `ColorPicker/Controls/` — `ColorWheel`, `ColorTriangle`, `ColorDisc`, `HslSlider`, `RgbSlider`, `AlphaSlider`, `LuminositySlider`, `DelegateSlider`
+- `ColorPicker/Behaviors/` — touch handling (`TouchBehavior`, `TouchActionEventArgs`)
+- `ColorPicker/Platforms/{Android,Windows}/` — touch behavior implementations per platform


### PR DESCRIPTION
Adds an `AGENTS.md` at the repo root with a curated set of practical notes for Copilot CLI (and any other agent that reads `AGENTS.md`).

The goal: future agent runs in this repo shouldn't have to re-discover the same quirks I've hit before. Topics covered:

- Repo layout (library / test app / UITests / ConsumerSmoke)
- Build commands per TFM; **the Android-only warning trap**
- **ConsumerSmoke gotcha**: PackageReference to the packed nupkg means it appears broken when built from the sln locally — only CI builds it
- CI pipeline (5 checks, ~12 min for full green)
- Branch protection / merge workflow (admin squash, no auto-merge)
- `.editorconfig` is mainstream .NET defaults; `dotnet format whitespace` has a known multi-line gap fixable with a small regex pass
- SkiaSharp (not ImageSharp) for imaging
- Common warning fixes seen so far (CS8767, CS8765, XML doc escaping)

No code changes. Safe to merge after CI.