### PR TITLE
docs: update AGENTS.md to reflect new branch protection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,13 +57,30 @@ Expect ~12-13 minutes for full green.
 
 ## Branch protection / merging
 
-**There is no branch protection.** Auto-merge does *not* work in this repo — it stays pending forever. Use admin merge for everything:
+`main` is protected:
+
+- PRs required (no direct push)
+- **All 5 PR CI checks must pass**, strict (branch must be up-to-date with main before merge)
+- 0 required reviews — solo project, so auto-merge from the author can fire as soon as CI is green
+- Force pushes / deletions disabled
+- Conversation resolution required
+- Admins **not** enforced — `gh pr merge --admin` still works as an emergency exit if you absolutely have to ship something past CI
+
+Normal merge flow:
+
+```bash
+gh pr merge N --squash --delete-branch --auto
+```
+
+`--auto` queues the merge so it fires automatically when all required checks pass. Convention is **squash** merges.
+
+Emergency / docs-only merges that don't need CI gating:
 
 ```bash
 gh pr merge N --admin --squash --delete-branch
 ```
 
-Squash merges are the convention here.
+Use sparingly — defeats the purpose of the gate.
 
 ## Formatting & style
 


### PR DESCRIPTION
Updates the merging section in AGENTS.md to reflect today's branch-protection change on main:

- All 5 PR CI checks now required (strict)
- 0 required reviews so auto-merge works for solo
- enforce_admins=false keeps admin merge as an emergency exit

The new normal flow is just: gh pr merge N --squash --delete-branch --auto