### PR TITLE
feat(core): scaffold ColorPicker.Core math library (Phase 0)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,6 +22,21 @@ permissions:
   contents: read
 
 jobs:
+  core-tests:
+    name: Core Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+      - name: Restore
+        run: dotnet restore ColorPicker.Core.Tests/ColorPicker.Core.Tests.csproj
+      - name: Test
+        run: dotnet test ColorPicker.Core.Tests/ColorPicker.Core.Tests.csproj --configuration Release --no-restore --logger "console;verbosity=normal"
+
   build-android:
     name: Build Android
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,8 @@ Practical notes accumulated from prior coding sessions. Read before working in t
 | Path | Purpose |
 |---|---|
 | `ColorPicker/` | The library — the published NuGet package (`ColorPicker.Maui`) |
+| `ColorPicker.Core/` | Pure platform-agnostic math (HSL/RGB, polar, unit-square primitives). No MAUI / Skia deps. Multi-targets `netstandard2.0` + `net8.0`. |
+| `ColorPicker.Core.Tests/` | xUnit tests for `ColorPicker.Core` (runs on every PR, ubuntu, sub-second) |
 | `ColorPickerTestApp/` | MAUI app for manual visual testing |
 | `ColorPicker.UITests/` | Appium-driven xUnit UI test suite (~213 tests) |
 | `samples/ConsumerSmoke/` | Smoke project that consumes the **packed nupkg**, *not* a ProjectReference |

--- a/ColorPicker.Core.Tests/ColorConversionsTests.cs
+++ b/ColorPicker.Core.Tests/ColorConversionsTests.cs
@@ -1,0 +1,109 @@
+namespace ColorPicker.Core.Tests;
+
+public class ColorConversionsTests
+{
+    const double Precision = 1e-9;
+    const double RgbTolerance = 1e-6;
+
+    public static IEnumerable<object[]> RgbHslSamples => new[]
+    {
+        // r, g, b, h, s, l
+        new object[] { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 },     // black
+        new object[] { 1.0, 1.0, 1.0, 0.0, 0.0, 1.0 },     // white
+        new object[] { 0.5, 0.5, 0.5, 0.0, 0.0, 0.5 },     // gray
+        new object[] { 1.0, 0.0, 0.0, 0.0,       1.0, 0.5 }, // red
+        new object[] { 0.0, 1.0, 0.0, 1.0 / 3.0, 1.0, 0.5 }, // green
+        new object[] { 0.0, 0.0, 1.0, 2.0 / 3.0, 1.0, 0.5 }, // blue
+        new object[] { 1.0, 1.0, 0.0, 1.0 / 6.0, 1.0, 0.5 }, // yellow
+        new object[] { 0.0, 1.0, 1.0, 0.5,       1.0, 0.5 }, // cyan
+        new object[] { 1.0, 0.0, 1.0, 5.0 / 6.0, 1.0, 0.5 }, // magenta
+    };
+
+    [Theory]
+    [MemberData(nameof(RgbHslSamples))]
+    public void RgbToHsl_KnownColors(double r, double g, double b, double h, double s, double l)
+    {
+        var hsl = ColorConversions.RgbToHsl(new RgbaColor(r, g, b));
+        Assert.Equal(h, hsl.H, Precision);
+        Assert.Equal(s, hsl.S, Precision);
+        Assert.Equal(l, hsl.L, Precision);
+    }
+
+    [Theory]
+    [MemberData(nameof(RgbHslSamples))]
+    public void HslToRgb_KnownColors(double r, double g, double b, double h, double s, double l)
+    {
+        var rgb = ColorConversions.HslToRgb(new HslaColor(h, s, l));
+        Assert.Equal(r, rgb.R, RgbTolerance);
+        Assert.Equal(g, rgb.G, RgbTolerance);
+        Assert.Equal(b, rgb.B, RgbTolerance);
+    }
+
+    [Theory]
+    [InlineData(0.0, 0.0, 0.0)]
+    [InlineData(0.1, 0.5, 0.2)]
+    [InlineData(0.7, 0.3, 0.4)]
+    [InlineData(0.99, 0.5, 0.6)]
+    public void HslRgbRoundTrip_PreservesValues(double h, double s, double l)
+    {
+        var orig = new HslaColor(h, s, l, 0.8);
+        var rt = orig.ToRgba().ToHsla();
+        // Hue is meaningless when saturation collapses (it shouldn't for these inputs)
+        Assert.Equal(orig.H, rt.H, RgbTolerance);
+        Assert.Equal(orig.S, rt.S, RgbTolerance);
+        Assert.Equal(orig.L, rt.L, RgbTolerance);
+        Assert.Equal(orig.A, rt.A);
+    }
+
+    [Theory]
+    [InlineData(0.0, 0.0, 0.0)]
+    [InlineData(0.1, 0.5, 0.2)]
+    [InlineData(0.7, 0.3, 0.9)]
+    [InlineData(0.99, 1.0, 0.5)]
+    public void HslHsvRoundTrip_PreservesValues(double h, double s, double l)
+    {
+        var orig = new HslaColor(h, s, l);
+        var rt = orig.ToHsva().ToHsla();
+        Assert.Equal(orig.H, rt.H, RgbTolerance);
+        Assert.Equal(orig.S, rt.S, RgbTolerance);
+        Assert.Equal(orig.L, rt.L, RgbTolerance);
+    }
+
+    [Fact]
+    public void HslToRgb_NegativeHue_WrapsAround()
+    {
+        var a = ColorConversions.HslToRgb(new HslaColor(-0.25, 1, 0.5));
+        var b = ColorConversions.HslToRgb(new HslaColor(0.75, 1, 0.5));
+        Assert.Equal(a.R, b.R, RgbTolerance);
+        Assert.Equal(a.G, b.G, RgbTolerance);
+        Assert.Equal(a.B, b.B, RgbTolerance);
+    }
+
+    [Fact]
+    public void HslToRgb_HueOver1_WrapsAround()
+    {
+        var a = ColorConversions.HslToRgb(new HslaColor(1.25, 1, 0.5));
+        var b = ColorConversions.HslToRgb(new HslaColor(0.25, 1, 0.5));
+        Assert.Equal(a.R, b.R, RgbTolerance);
+        Assert.Equal(a.G, b.G, RgbTolerance);
+        Assert.Equal(a.B, b.B, RgbTolerance);
+    }
+
+    [Fact]
+    public void HsvToRgb_AllSaturationZero_IsGrayscale()
+    {
+        var rgb = ColorConversions.HsvToRgb(new HsvaColor(0.7, 0, 0.4));
+        Assert.Equal(0.4, rgb.R, RgbTolerance);
+        Assert.Equal(0.4, rgb.G, RgbTolerance);
+        Assert.Equal(0.4, rgb.B, RgbTolerance);
+    }
+
+    [Fact]
+    public void AlphaIsPreservedThroughAllConversions()
+    {
+        var hsl = new HslaColor(0.5, 0.5, 0.5, 0.42);
+        Assert.Equal(0.42, hsl.ToRgba().A);
+        Assert.Equal(0.42, hsl.ToHsva().A);
+        Assert.Equal(0.42, hsl.ToRgba().ToHsla().A);
+    }
+}

--- a/ColorPicker.Core.Tests/ColorPicker.Core.Tests.csproj
+++ b/ColorPicker.Core.Tests/ColorPicker.Core.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>ColorPicker.Core.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ColorPicker.Core\ColorPicker.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ColorPicker.Core.Tests/GlobalUsings.cs
+++ b/ColorPicker.Core.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/ColorPicker.Core.Tests/HslChannelSlidersTests.cs
+++ b/ColorPicker.Core.Tests/HslChannelSlidersTests.cs
@@ -1,0 +1,102 @@
+namespace ColorPicker.Core.Tests;
+
+public class HslChannelSlidersTests
+{
+    static readonly HslaColor Base = new(0.25, 0.6, 0.4, 0.8);
+
+    [Fact]
+    public void HueSlider_RoundTrip()
+    {
+        var s = new HueSlider();
+        var p = s.ColorToPoint(Base);
+        Assert.Equal(0.25f, p.X, 1e-5);
+        Assert.Equal(0.5f,  p.Y, 1e-5);
+
+        var c = s.UpdateColor(new UnitPoint(0.75f, 0.5f), Base);
+        Assert.Equal(0.75, c.H, 1e-5);
+        Assert.Equal(Base.S, c.S);
+        Assert.Equal(Base.L, c.L);
+        Assert.Equal(Base.A, c.A);
+    }
+
+    [Fact]
+    public void SaturationSlider_ReadsSaturation()
+    {
+        var s = new SaturationSlider();
+        Assert.Equal(0.6f, s.ColorToPoint(Base).X, 1e-5);
+        var c = s.UpdateColor(new UnitPoint(0.2f, 0.5f), Base);
+        Assert.Equal(0.2, c.S, 1e-5);
+        Assert.Equal(Base.H, c.H);
+    }
+
+    [Fact]
+    public void LuminositySlider_ReadsLuminosity()
+    {
+        var s = new LuminositySlider();
+        Assert.Equal(0.4f, s.ColorToPoint(Base).X, 1e-5);
+        var c = s.UpdateColor(new UnitPoint(0.9f, 0.5f), Base);
+        Assert.Equal(0.9, c.L, 1e-5);
+    }
+
+    [Fact]
+    public void AlphaSlider_ReadsAlpha()
+    {
+        var s = new AlphaSlider();
+        Assert.Equal(0.8f, s.ColorToPoint(Base).X, 1e-5);
+        var c = s.UpdateColor(new UnitPoint(0.1f, 0.5f), Base);
+        Assert.Equal(0.1, c.A, 1e-5);
+    }
+
+    [Fact]
+    public void VerticalSlider_UsesYAxis()
+    {
+        var s = new HueSlider(vertical: true);
+        var p = s.ColorToPoint(Base);
+        Assert.Equal(0.5f,  p.X, 1e-5);
+        Assert.Equal(0.25f, p.Y, 1e-5);
+        var c = s.UpdateColor(new UnitPoint(0.5f, 0.7f), Base);
+        Assert.Equal(0.7, c.H, 1e-5);
+    }
+
+    [Fact]
+    public void FitToActiveArea_SnapsCrossAxisToCenter()
+    {
+        var s = new HueSlider();
+        var p = s.FitToActiveArea(new UnitPoint(0.3f, 0.9f), Base);
+        Assert.Equal(0.3f, p.X, 1e-5);
+        Assert.Equal(0.5f, p.Y, 1e-5);
+    }
+
+    [Fact]
+    public void IsInActiveArea_AlwaysTrue()
+    {
+        var s = new HueSlider();
+        Assert.True(s.IsInActiveArea(new UnitPoint(0f, 0f), Base));
+        Assert.True(s.IsInActiveArea(new UnitPoint(2f, -3f), Base));
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(0.33)]
+    [InlineData(0.67)]
+    [InlineData(1.0)]
+    public void AllChannelSliders_RoundTrip(double v)
+    {
+        var c = new HslaColor(v, v, v, v);
+        foreach (var s in new HslChannelSlider[]
+        {
+            new HueSlider(), new SaturationSlider(),
+            new LuminositySlider(), new AlphaSlider(),
+        })
+        {
+            var p = s.ColorToPoint(c);
+            var back = s.UpdateColor(p, c);
+            // each slider mutates its own channel; the round-trip leaves
+            // every other channel untouched, so back == c.
+            Assert.Equal(c.H, back.H, 1e-6);
+            Assert.Equal(c.S, back.S, 1e-6);
+            Assert.Equal(c.L, back.L, 1e-6);
+            Assert.Equal(c.A, back.A, 1e-6);
+        }
+    }
+}

--- a/ColorPicker.Core.Tests/HueSaturationDiscTests.cs
+++ b/ColorPicker.Core.Tests/HueSaturationDiscTests.cs
@@ -1,0 +1,140 @@
+namespace ColorPicker.Core.Tests;
+
+public class HueSaturationDiscTests
+{
+    const double Precision = 1e-6;
+    readonly HueSaturationDisc _disc = new();
+
+    // ---- IsInActiveArea ----------------------------------------------------
+
+    [Theory]
+    [InlineData(0.5f, 0.5f, true)]   // center
+    [InlineData(0.0f, 0.5f, true)]   // left edge (radius 0.5)
+    [InlineData(1.0f, 0.5f, true)]   // right edge
+    [InlineData(0.5f, 0.0f, true)]   // top edge
+    [InlineData(0.5f, 1.0f, true)]   // bottom edge
+    [InlineData(0.0f, 0.0f, false)]  // top-left corner (radius √0.5 ≈ 0.707)
+    [InlineData(1.0f, 1.0f, false)]  // bottom-right corner
+    public void IsInActiveArea_MatchesUnitDisc(float x, float y, bool expected)
+    {
+        var inside = _disc.IsInActiveArea(new UnitPoint(x, y), default);
+        Assert.Equal(expected, inside);
+    }
+
+    // ---- FitToActiveArea ---------------------------------------------------
+
+    [Theory]
+    [InlineData(0.5f, 0.5f)]
+    [InlineData(0.25f, 0.5f)]
+    [InlineData(0.5f, 0.25f)]
+    public void FitToActiveArea_LeavesInteriorUntouched(float x, float y)
+    {
+        var p = new UnitPoint(x, y);
+        var f = _disc.FitToActiveArea(p, default);
+        Assert.Equal(p.X, f.X, Precision);
+        Assert.Equal(p.Y, f.Y, Precision);
+    }
+
+    [Theory]
+    [InlineData(0.0f, 0.0f)] // top-left corner clamps to disc boundary along same direction
+    [InlineData(1.0f, 1.0f)]
+    [InlineData(1.0f, 0.0f)]
+    [InlineData(0.0f, 1.0f)]
+    public void FitToActiveArea_ProjectsExteriorOntoBoundary(float x, float y)
+    {
+        var fit = _disc.FitToActiveArea(new UnitPoint(x, y), default);
+        var rOut = fit.ToCentered().ToPolar().Radius;
+        Assert.Equal(0.5f, rOut, 1e-5);
+    }
+
+    // ---- ColorToPoint ------------------------------------------------------
+
+    [Theory]
+    [InlineData(0.0,  1.0, 0.0f, 0.5f)]    // hue 0   → angle π   → left  edge
+    [InlineData(0.25, 1.0, 0.5f, 1.0f)]    // hue 0.25→ angle π/2 → bottom edge (screen +Y)
+    [InlineData(0.5,  1.0, 1.0f, 0.5f)]    // hue 0.5 → angle 0   → right edge
+    [InlineData(0.75, 1.0, 0.5f, 0.0f)]    // hue 0.75→ angle −π/2→ top    edge
+    public void ColorToPoint_HueOnSaturatedBoundary(double h, double s, float expX, float expY)
+    {
+        var p = _disc.ColorToPoint(new HslaColor(h, s, 0.5));
+        Assert.Equal(expX, p.X, 1e-5);
+        Assert.Equal(expY, p.Y, 1e-5);
+    }
+
+    [Fact]
+    public void ColorToPoint_ZeroSaturation_LandsAtCenter()
+    {
+        var p = _disc.ColorToPoint(new HslaColor(0.42, 0.0, 0.5));
+        Assert.Equal(0.5f, p.X, 1e-5);
+        Assert.Equal(0.5f, p.Y, 1e-5);
+    }
+
+    [Fact]
+    public void ColorToPoint_HalfSaturation_LandsAtHalfRadius()
+    {
+        var p = _disc.ColorToPoint(new HslaColor(0.5, 0.5, 0.5));
+        // hue 0.5 → angle 0 → +X axis, radius 0.25 → (0.75, 0.5)
+        Assert.Equal(0.75f, p.X, 1e-5);
+        Assert.Equal(0.5f,  p.Y, 1e-5);
+    }
+
+    // ---- Round trips -------------------------------------------------------
+
+    [Theory]
+    [InlineData(0.00, 1.00)]
+    [InlineData(0.10, 0.80)]
+    [InlineData(0.25, 0.50)]
+    [InlineData(0.50, 1.00)]
+    [InlineData(0.75, 0.30)]
+    [InlineData(0.99, 1.00)]
+    public void RoundTrip_ColorToPointToColor_PreservesHueAndSaturation(double h, double s)
+    {
+        var orig = new HslaColor(h, s, 0.5, 0.7);
+        var p = _disc.ColorToPoint(orig);
+        var back = _disc.UpdateColor(p, orig);
+        // Hue wraps at 1, so compare as circular distance.
+        var dh = Math.Abs(orig.H - back.H);
+        dh = Math.Min(dh, 1.0 - dh);
+        Assert.True(dh < 1e-5, $"hue drifted: orig={orig.H} back={back.H}");
+        Assert.Equal(orig.S, back.S, 1e-5);
+        // L and A are passed through unchanged
+        Assert.Equal(orig.L, back.L);
+        Assert.Equal(orig.A, back.A);
+    }
+
+    [Fact]
+    public void UpdateColor_HueWrapsToUnitInterval()
+    {
+        // A point near top of disc could mathematically give a negative
+        // intermediate hue from (π − angle)/(2π); ensure we wrap to [0, 1).
+        var color = new HslaColor(0, 0.5, 0.5);
+        for (int i = 0; i < 360; i++)
+        {
+            double ang = i * Math.PI / 180.0;
+            var p = new PolarPoint(0.3f, (float)ang).ToCartesian().FromCentered();
+            var result = _disc.UpdateColor(p, color);
+            Assert.InRange(result.H, 0.0, 1.0);
+            Assert.InRange(result.S, 0.0, 1.0);
+        }
+    }
+
+    [Fact]
+    public void UpdateColor_OutOfBoundsPoint_ClampsSaturationAtMost1()
+    {
+        var color = new HslaColor(0, 0.5, 0.5);
+        // Way outside the unit square
+        var p = new UnitPoint(2f, 2f);
+        var result = _disc.UpdateColor(p, color);
+        Assert.Equal(1.0, result.S, 1e-5);
+    }
+
+    [Fact]
+    public void UpdateColor_PreservesLuminosityAndAlpha()
+    {
+        var color = new HslaColor(0.1, 0.2, 0.85, 0.4);
+        var p = new UnitPoint(0.7f, 0.3f);
+        var result = _disc.UpdateColor(p, color);
+        Assert.Equal(color.L, result.L);
+        Assert.Equal(color.A, result.A);
+    }
+}

--- a/ColorPicker.Core.Tests/LinearTrackTests.cs
+++ b/ColorPicker.Core.Tests/LinearTrackTests.cs
@@ -1,0 +1,49 @@
+namespace ColorPicker.Core.Tests;
+
+public class LinearTrackTests
+{
+    [Theory]
+    [InlineData(false, 0.0f, 0.5f, 0.0)]
+    [InlineData(false, 0.5f, 0.5f, 0.5)]
+    [InlineData(false, 1.0f, 0.5f, 1.0)]
+    [InlineData(true,  0.5f, 0.0f, 0.0)]
+    [InlineData(true,  0.5f, 0.5f, 0.5)]
+    [InlineData(true,  0.5f, 1.0f, 1.0)]
+    public void ValueAt_KnownPositions(bool vertical, float x, float y, double expected)
+    {
+        var t = new LinearTrack(vertical);
+        Assert.Equal(expected, t.ValueAt(new UnitPoint(x, y)), 1e-6);
+    }
+
+    [Theory]
+    [InlineData(false, 0.0, 0.0f, 0.5f)]
+    [InlineData(false, 0.5, 0.5f, 0.5f)]
+    [InlineData(false, 1.0, 1.0f, 0.5f)]
+    [InlineData(true,  0.5, 0.5f, 0.5f)]
+    public void PointFor_KnownValues(bool vertical, double v, float ex, float ey)
+    {
+        var t = new LinearTrack(vertical);
+        var p = t.PointFor(v);
+        Assert.Equal(ex, p.X, 1e-5);
+        Assert.Equal(ey, p.Y, 1e-5);
+    }
+
+    [Theory]
+    [InlineData(-1.0, 0.0)]
+    [InlineData( 0.5, 0.5)]
+    [InlineData( 2.0, 1.0)]
+    public void PointFor_ClampsOutOfRange(double v, double expected)
+    {
+        var t = new LinearTrack(false);
+        Assert.Equal(expected, t.PointFor(v).X, 1e-6);
+    }
+
+    [Theory]
+    [InlineData(-0.5f, 0.0)]
+    [InlineData( 1.5f, 1.0)]
+    public void ValueAt_ClampsOutOfRange(float x, double expected)
+    {
+        var t = new LinearTrack(false);
+        Assert.Equal(expected, t.ValueAt(new UnitPoint(x, 0.5f)), 1e-6);
+    }
+}

--- a/ColorPicker.Core.Tests/LuminosityRingTests.cs
+++ b/ColorPicker.Core.Tests/LuminosityRingTests.cs
@@ -1,0 +1,141 @@
+namespace ColorPicker.Core.Tests;
+
+public class LuminosityRingTests
+{
+    readonly LuminosityRing _ring = new();
+
+    // ---- ColorToPoint: known positions ------------------------------------
+
+    [Fact]
+    public void ColorToPoint_L0_LandsAtTop()
+    {
+        var p = _ring.ColorToPoint(new HslaColor(0.3, 0.5, 0.0));
+        Assert.Equal(0.5f, p.X, 1e-5);
+        Assert.Equal(0.0f, p.Y, 1e-5); // top edge (screen y=0)
+    }
+
+    [Fact]
+    public void ColorToPoint_L1_LandsAtBottom()
+    {
+        var p = _ring.ColorToPoint(new HslaColor(0.3, 0.5, 1.0));
+        Assert.Equal(0.5f, p.X, 1e-5);
+        Assert.Equal(1.0f, p.Y, 1e-5);
+    }
+
+    [Fact]
+    public void ColorToPoint_LHalf_DefaultsToRightSide()
+    {
+        var p = _ring.ColorToPoint(new HslaColor(0.3, 0.5, 0.5));
+        Assert.Equal(1.0f, p.X, 1e-5);
+        Assert.Equal(0.5f, p.Y, 1e-5);
+    }
+
+    [Fact]
+    public void ColorToPoint_WithPrevPointOnLeft_StaysOnLeft()
+    {
+        // Previous indicator at 9 o'clock (left edge)
+        var prev = new UnitPoint(0f, 0.5f);
+        var p = _ring.ColorToPoint(new HslaColor(0.3, 0.5, 0.5), prev);
+        Assert.Equal(0.0f, p.X, 1e-5);
+        Assert.Equal(0.5f, p.Y, 1e-5);
+    }
+
+    [Fact]
+    public void ColorToPoint_WithPrevPointOnRight_StaysOnRight()
+    {
+        var prev = new UnitPoint(1f, 0.5f);
+        var p = _ring.ColorToPoint(new HslaColor(0.3, 0.5, 0.5), prev);
+        Assert.Equal(1.0f, p.X, 1e-5);
+        Assert.Equal(0.5f, p.Y, 1e-5);
+    }
+
+    // ---- UpdateColor: known positions -------------------------------------
+
+    [Theory]
+    [InlineData(0.5f, 0.0f, 0.0)]   // top   → L=0
+    [InlineData(0.5f, 1.0f, 1.0)]   // bottom→ L=1
+    [InlineData(1.0f, 0.5f, 0.5)]   // right → L=0.5
+    [InlineData(0.0f, 0.5f, 0.5)]   // left  → L=0.5 (sign lost)
+    public void UpdateColor_KnownPositions(float x, float y, double expL)
+    {
+        var c = _ring.UpdateColor(new UnitPoint(x, y), new HslaColor(0.3, 0.5, 0));
+        Assert.Equal(expL, c.L, 1e-5);
+    }
+
+    [Fact]
+    public void UpdateColor_PreservesHSAandWrapsLuminosity()
+    {
+        var orig = new HslaColor(0.42, 0.6, 0.0, 0.7);
+        var c = _ring.UpdateColor(new UnitPoint(0.85f, 0.85f), orig);
+        Assert.Equal(orig.H, c.H);
+        Assert.Equal(orig.S, c.S);
+        Assert.Equal(orig.A, c.A);
+        Assert.InRange(c.L, 0.0, 1.0);
+    }
+
+    // ---- Round trips -------------------------------------------------------
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(0.1)]
+    [InlineData(0.25)]
+    [InlineData(0.5)]
+    [InlineData(0.75)]
+    [InlineData(1.0)]
+    public void RoundTrip_DefaultSide(double l)
+    {
+        var orig = new HslaColor(0.2, 0.7, l, 0.5);
+        var p = _ring.ColorToPoint(orig);
+        var back = _ring.UpdateColor(p, orig);
+        Assert.Equal(orig.L, back.L, 1e-5);
+    }
+
+    [Theory]
+    [InlineData(0.1)]
+    [InlineData(0.5)]
+    [InlineData(0.9)]
+    public void RoundTrip_WithLeftSideHint(double l)
+    {
+        var orig = new HslaColor(0.2, 0.7, l, 0.5);
+        var p = _ring.ColorToPoint(orig, new UnitPoint(0f, 0.5f));
+        Assert.True(p.X <= 0.5f, $"expected left half, got X={p.X}");
+        var back = _ring.UpdateColor(p, orig);
+        Assert.Equal(orig.L, back.L, 1e-5);
+    }
+
+    // ---- IsInActiveArea ---------------------------------------------------
+
+    [Fact]
+    public void IsInActiveArea_PointOnRing_IsActive()
+    {
+        // 3 o'clock, exactly on ring
+        var p = new UnitPoint(1f, 0.5f);
+        Assert.True(_ring.IsInActiveArea(p, default));
+    }
+
+    [Fact]
+    public void IsInActiveArea_PointAtCenter_NotActive()
+    {
+        var p = new UnitPoint(0.5f, 0.5f);
+        Assert.False(_ring.IsInActiveArea(p, default));
+    }
+
+    // ---- FitToActiveArea --------------------------------------------------
+
+    [Fact]
+    public void FitToActiveArea_OffRingPoint_ProjectsToRingRadius()
+    {
+        var p = new UnitPoint(0.75f, 0.5f); // radius 0.25
+        var fit = _ring.FitToActiveArea(p, default);
+        var r = fit.ToCentered().ToPolar().Radius;
+        Assert.Equal(0.5f, r, 1e-5);
+    }
+
+    [Fact]
+    public void FitToActiveArea_Center_DefaultsToRightSide()
+    {
+        var fit = _ring.FitToActiveArea(new UnitPoint(0.5f, 0.5f), default);
+        Assert.Equal(1.0f, fit.X, 1e-5);
+        Assert.Equal(0.5f, fit.Y, 1e-5);
+    }
+}

--- a/ColorPicker.Core.Tests/PolarPointTests.cs
+++ b/ColorPicker.Core.Tests/PolarPointTests.cs
@@ -1,0 +1,82 @@
+namespace ColorPicker.Core.Tests;
+
+public class PolarPointTests
+{
+    const float Precision = 1e-6f;
+
+    [Fact]
+    public void Constructor_StoresRadius_AndNormalizesAngleToCanonicalRange()
+    {
+        var p = new PolarPoint(0, 0);
+        Assert.Equal(0, p.Radius);
+        Assert.Equal(0, p.Angle);
+    }
+
+    [Theory]
+    [InlineData(1f, 0f, 0f)]                  // +X axis
+    [InlineData(1f, (float)Math.PI, (float)Math.PI)]    // -X axis (±π collapses to π or -π)
+    [InlineData(1f, 2 * (float)Math.PI, 0f)]            // wraps to 0
+    [InlineData(1f, 3 * (float)Math.PI, (float)Math.PI)] // wraps to π
+    public void Constructor_NormalizesAngle(float r, float angle, float expectedAbsAngle)
+    {
+        var p = new PolarPoint(r, angle);
+        Assert.Equal(r, p.Radius);
+        Assert.Equal(expectedAbsAngle, Math.Abs(p.Angle), Precision);
+    }
+
+    [Fact]
+    public void FromCartesian_Origin_RadiusZero()
+    {
+        var p = PolarPoint.FromCartesian(0, 0);
+        Assert.Equal(0, p.Radius);
+        Assert.Equal(0, p.Angle);
+    }
+
+    [Theory]
+    [InlineData(1f, 0f, 1f, 0f)]
+    [InlineData(0f, 1f, 1f, (float)(Math.PI / 2))]
+    [InlineData(0f, -1f, 1f, -(float)(Math.PI / 2))]
+    [InlineData(-1f, 0f, 1f, (float)Math.PI)]
+    public void FromCartesian_KnownPoints(float x, float y, float expectedR, float expectedA)
+    {
+        var p = PolarPoint.FromCartesian(x, y);
+        Assert.Equal(expectedR, p.Radius, Precision);
+        Assert.Equal(Math.Abs(expectedA), Math.Abs(p.Angle), Precision);
+    }
+
+    [Fact]
+    public void ToCartesian_AndBack_RoundTrips()
+    {
+        var input = new UnitPoint(0.3f, -0.4f);
+        var polar = input.ToPolar();
+        var back = polar.ToCartesian();
+        Assert.Equal(input.X, back.X, Precision);
+        Assert.Equal(input.Y, back.Y, Precision);
+    }
+
+    [Fact]
+    public void AddAngle_NormalizesResult()
+    {
+        var p = new PolarPoint(1, (float)Math.PI).AddAngle((float)Math.PI);
+        Assert.Equal(0, p.Angle, Precision);
+    }
+
+    [Fact]
+    public void WithMethods_AreImmutable()
+    {
+        var a = new PolarPoint(1, 0);
+        var b = a.WithRadius(2);
+        Assert.Equal(1, a.Radius);
+        Assert.Equal(2, b.Radius);
+    }
+
+    [Fact]
+    public void Equality_StructuralAndOperator()
+    {
+        var a = new PolarPoint(1, 0);
+        var b = new PolarPoint(1, 0);
+        Assert.True(a == b);
+        Assert.True(a.Equals(b));
+        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+    }
+}

--- a/ColorPicker.Core.Tests/UnitPointTests.cs
+++ b/ColorPicker.Core.Tests/UnitPointTests.cs
@@ -1,0 +1,67 @@
+namespace ColorPicker.Core.Tests;
+
+public class UnitPointTests
+{
+    const float Precision = 1e-6f;
+
+    [Fact]
+    public void Constructor_StoresCoordinates()
+    {
+        var p = new UnitPoint(0.25f, 0.75f);
+        Assert.Equal(0.25f, p.X);
+        Assert.Equal(0.75f, p.Y);
+    }
+
+    [Fact]
+    public void ToCentered_ShiftsByMinusHalf()
+    {
+        var p = new UnitPoint(0.5f, 0.5f).ToCentered();
+        Assert.Equal(0f, p.X);
+        Assert.Equal(0f, p.Y);
+    }
+
+    [Fact]
+    public void FromCentered_ShiftsByPlusHalf()
+    {
+        var p = new UnitPoint(0f, 0f).FromCentered();
+        Assert.Equal(0.5f, p.X);
+        Assert.Equal(0.5f, p.Y);
+    }
+
+    [Fact]
+    public void Centered_RoundTripIsIdentity()
+    {
+        var p = new UnitPoint(0.3f, 0.7f);
+        var rt = p.ToCentered().FromCentered();
+        Assert.Equal(p.X, rt.X, Precision);
+        Assert.Equal(p.Y, rt.Y, Precision);
+    }
+
+    [Fact]
+    public void WithMethods_AreImmutable()
+    {
+        var a = new UnitPoint(0.1f, 0.2f);
+        var b = a.WithX(0.9f);
+        Assert.Equal(0.1f, a.X);
+        Assert.Equal(0.9f, b.X);
+        Assert.Equal(0.2f, b.Y);
+    }
+
+    [Fact]
+    public void Translate_AddsDeltas()
+    {
+        var p = new UnitPoint(0.1f, 0.2f).Translate(0.4f, -0.1f);
+        Assert.Equal(0.5f, p.X, Precision);
+        Assert.Equal(0.1f, p.Y, Precision);
+    }
+
+    [Fact]
+    public void Equality_Structural()
+    {
+        var a = new UnitPoint(0.1f, 0.2f);
+        var b = new UnitPoint(0.1f, 0.2f);
+        var c = new UnitPoint(0.1f, 0.3f);
+        Assert.True(a == b);
+        Assert.True(a != c);
+    }
+}

--- a/ColorPicker.Core/ColorConversions.cs
+++ b/ColorPicker.Core/ColorConversions.cs
@@ -1,0 +1,143 @@
+namespace ColorPicker.Core;
+
+/// <summary>
+/// Pure conversions between RGB, HSL and HSV color spaces.
+/// All channels are doubles in [0, 1]. Hue is also [0, 1] (i.e. 0..360° / 360).
+///
+/// Algorithms follow the standard formulas:
+/// https://en.wikipedia.org/wiki/HSL_and_HSV#Color_conversion_formulae
+/// </summary>
+public static class ColorConversions
+{
+    public static RgbaColor HslToRgb(HslaColor hsla)
+    {
+        double h = WrapHue(hsla.H);
+        double s = Clamp01(hsla.S);
+        double l = Clamp01(hsla.L);
+
+        if (s == 0.0)
+            return new RgbaColor(l, l, l, hsla.A);
+
+        double q = l < 0.5 ? l * (1 + s) : l + s - (l * s);
+        double p = (2 * l) - q;
+
+        double r = HueToRgb(p, q, h + (1.0 / 3.0));
+        double g = HueToRgb(p, q, h);
+        double b = HueToRgb(p, q, h - (1.0 / 3.0));
+
+        return new RgbaColor(r, g, b, hsla.A);
+    }
+
+    public static HslaColor RgbToHsl(RgbaColor rgba)
+    {
+        double r = Clamp01(rgba.R);
+        double g = Clamp01(rgba.G);
+        double b = Clamp01(rgba.B);
+
+        double max = Math.Max(r, Math.Max(g, b));
+        double min = Math.Min(r, Math.Min(g, b));
+        double l = (max + min) / 2.0;
+
+        if (max == min)
+            return new HslaColor(0, 0, l, rgba.A);
+
+        double d = max - min;
+        double s = l > 0.5 ? d / (2.0 - max - min) : d / (max + min);
+
+        double h;
+        if (max == r)
+            h = ((g - b) / d) + (g < b ? 6.0 : 0.0);
+        else if (max == g)
+            h = ((b - r) / d) + 2.0;
+        else
+            h = ((r - g) / d) + 4.0;
+        h /= 6.0;
+
+        return new HslaColor(h, s, l, rgba.A);
+    }
+
+    public static RgbaColor HsvToRgb(HsvaColor hsva)
+    {
+        double h = WrapHue(hsva.H) * 6.0;
+        double s = Clamp01(hsva.S);
+        double v = Clamp01(hsva.V);
+
+        int i = (int)Math.Floor(h) % 6;
+        double f = h - Math.Floor(h);
+        double p = v * (1 - s);
+        double q = v * (1 - (f * s));
+        double t = v * (1 - ((1 - f) * s));
+
+        return i switch
+        {
+            0 => new RgbaColor(v, t, p, hsva.A),
+            1 => new RgbaColor(q, v, p, hsva.A),
+            2 => new RgbaColor(p, v, t, hsva.A),
+            3 => new RgbaColor(p, q, v, hsva.A),
+            4 => new RgbaColor(t, p, v, hsva.A),
+            _ => new RgbaColor(v, p, q, hsva.A),
+        };
+    }
+
+    public static HsvaColor RgbToHsv(RgbaColor rgba)
+    {
+        double r = Clamp01(rgba.R);
+        double g = Clamp01(rgba.G);
+        double b = Clamp01(rgba.B);
+
+        double max = Math.Max(r, Math.Max(g, b));
+        double min = Math.Min(r, Math.Min(g, b));
+        double v = max;
+        double d = max - min;
+        double s = max == 0 ? 0 : d / max;
+
+        double h;
+        if (d == 0)
+            h = 0;
+        else if (max == r)
+            h = ((g - b) / d) + (g < b ? 6.0 : 0.0);
+        else if (max == g)
+            h = ((b - r) / d) + 2.0;
+        else
+            h = ((r - g) / d) + 4.0;
+        h /= 6.0;
+
+        return new HsvaColor(h, s, v, rgba.A);
+    }
+
+    public static HsvaColor HslToHsv(HslaColor hsla)
+    {
+        double l = Clamp01(hsla.L);
+        double s = Clamp01(hsla.S);
+        double v = l + (s * Math.Min(l, 1 - l));
+        double sv = v == 0 ? 0 : 2 * (1 - (l / v));
+        return new HsvaColor(hsla.H, sv, v, hsla.A);
+    }
+
+    public static HslaColor HsvToHsl(HsvaColor hsva)
+    {
+        double v = Clamp01(hsva.V);
+        double s = Clamp01(hsva.S);
+        double l = v * (1 - (s / 2.0));
+        double sl = (l == 0 || l == 1) ? 0 : (v - l) / Math.Min(l, 1 - l);
+        return new HslaColor(hsva.H, sl, l, hsva.A);
+    }
+
+    static double HueToRgb(double p, double q, double t)
+    {
+        if (t < 0) t += 1;
+        if (t > 1) t -= 1;
+        if (t < 1.0 / 6.0) return p + ((q - p) * 6 * t);
+        if (t < 1.0 / 2.0) return q;
+        if (t < 2.0 / 3.0) return p + ((q - p) * ((2.0 / 3.0) - t) * 6);
+        return p;
+    }
+
+    static double Clamp01(double v) => v < 0 ? 0 : v > 1 ? 1 : v;
+
+    static double WrapHue(double h)
+    {
+        h %= 1.0;
+        return h < 0 ? h + 1.0 : h;
+    }
+}

--- a/ColorPicker.Core/ColorPicker.Core.csproj
+++ b/ColorPicker.Core/ColorPicker.Core.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <RootNamespace>ColorPicker.Core</RootNamespace>
+    <AssemblyName>ColorPicker.Core</AssemblyName>
+    <Description>Platform-agnostic math for the ColorPicker.Maui library: HSL/RGB conversions, polar geometry, unit-square color-picker primitives.</Description>
+    <PackageTags>colorpicker;hsl;hsv;rgb;color;math</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="ColorPicker.Core.Tests" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
+  </ItemGroup>
+
+</Project>

--- a/ColorPicker.Core/HslChannelSliders.cs
+++ b/ColorPicker.Core/HslChannelSliders.cs
@@ -1,0 +1,58 @@
+namespace ColorPicker.Core;
+
+/// <summary>
+/// Base class for HSL channel sliders (Hue / Saturation / Luminosity /
+/// Alpha). Each subclass plugs in a read/write pair for its specific
+/// channel; the geometry comes from <see cref="LinearTrack"/>.
+///
+/// All channel sliders treat the entire unit square as their active area —
+/// any tap is mapped to the track via <see cref="FitToActiveArea"/>. (Pixel
+/// thickness / hit tolerance lives in the render layer, not here.)
+/// </summary>
+public abstract class HslChannelSlider : IColorPickerArea
+{
+    public LinearTrack Track { get; }
+
+    protected HslChannelSlider(LinearTrack track) { Track = track; }
+
+    public bool IsInActiveArea(UnitPoint point, HslaColor color) => true;
+
+    public UnitPoint FitToActiveArea(UnitPoint point, HslaColor color)
+        => Track.PointFor(Track.ValueAt(point));
+
+    public HslaColor UpdateColor(UnitPoint point, HslaColor color)
+        => Write(color, Track.ValueAt(point));
+
+    public UnitPoint ColorToPoint(HslaColor color) => Track.PointFor(Read(color));
+
+    protected abstract double Read(HslaColor color);
+    protected abstract HslaColor Write(HslaColor color, double value);
+}
+
+public sealed class HueSlider : HslChannelSlider
+{
+    public HueSlider(bool vertical = false) : base(new LinearTrack(vertical)) { }
+    protected override double Read(HslaColor c) => c.H;
+    protected override HslaColor Write(HslaColor c, double v) => c.WithH(v);
+}
+
+public sealed class SaturationSlider : HslChannelSlider
+{
+    public SaturationSlider(bool vertical = false) : base(new LinearTrack(vertical)) { }
+    protected override double Read(HslaColor c) => c.S;
+    protected override HslaColor Write(HslaColor c, double v) => c.WithS(v);
+}
+
+public sealed class LuminositySlider : HslChannelSlider
+{
+    public LuminositySlider(bool vertical = false) : base(new LinearTrack(vertical)) { }
+    protected override double Read(HslaColor c) => c.L;
+    protected override HslaColor Write(HslaColor c, double v) => c.WithL(v);
+}
+
+public sealed class AlphaSlider : HslChannelSlider
+{
+    public AlphaSlider(bool vertical = false) : base(new LinearTrack(vertical)) { }
+    protected override double Read(HslaColor c) => c.A;
+    protected override HslaColor Write(HslaColor c, double v) => c.WithA(v);
+}

--- a/ColorPicker.Core/HslaColor.cs
+++ b/ColorPicker.Core/HslaColor.cs
@@ -1,0 +1,40 @@
+namespace ColorPicker.Core;
+
+/// <summary>
+/// HSLA color in [0, 1] × [0, 1] × [0, 1] × [0, 1].
+/// Pure value type, no framework dependencies.
+/// </summary>
+public readonly struct HslaColor : IEquatable<HslaColor>
+{
+    public double H { get; }
+    public double S { get; }
+    public double L { get; }
+    public double A { get; }
+
+    public HslaColor(double h, double s, double l, double a = 1.0)
+    {
+        H = h;
+        S = s;
+        L = l;
+        A = a;
+    }
+
+    public HslaColor WithH(double h) => new(h, S, L, A);
+    public HslaColor WithS(double s) => new(H, s, L, A);
+    public HslaColor WithL(double l) => new(H, S, l, A);
+    public HslaColor WithA(double a) => new(H, S, L, a);
+
+    public RgbaColor ToRgba() => ColorConversions.HslToRgb(this);
+    public HsvaColor ToHsva() => ColorConversions.HslToHsv(this);
+
+    public static HslaColor FromRgba(RgbaColor rgba) => ColorConversions.RgbToHsl(rgba);
+    public static HslaColor FromHsva(HsvaColor hsva) => ColorConversions.HsvToHsl(hsva);
+
+    public bool Equals(HslaColor other) => H == other.H && S == other.S && L == other.L && A == other.A;
+    public override bool Equals(object? obj) => obj is HslaColor other && Equals(other);
+    public override int GetHashCode() => HashCode.Combine(H, S, L, A);
+    public static bool operator ==(HslaColor a, HslaColor b) => a.Equals(b);
+    public static bool operator !=(HslaColor a, HslaColor b) => !a.Equals(b);
+
+    public override string ToString() => $"hsla({H}, {S}, {L}, {A})";
+}

--- a/ColorPicker.Core/HsvaColor.cs
+++ b/ColorPicker.Core/HsvaColor.cs
@@ -1,0 +1,37 @@
+namespace ColorPicker.Core;
+
+/// <summary>
+/// HSVA color in [0, 1] × [0, 1] × [0, 1] × [0, 1].
+/// Used by the triangle picker, which expresses color in HSV space.
+/// </summary>
+public readonly struct HsvaColor : IEquatable<HsvaColor>
+{
+    public double H { get; }
+    public double S { get; }
+    public double V { get; }
+    public double A { get; }
+
+    public HsvaColor(double h, double s, double v, double a = 1.0)
+    {
+        H = h;
+        S = s;
+        V = v;
+        A = a;
+    }
+
+    public HsvaColor WithH(double h) => new(h, S, V, A);
+    public HsvaColor WithS(double s) => new(H, s, V, A);
+    public HsvaColor WithV(double v) => new(H, S, v, A);
+    public HsvaColor WithA(double a) => new(H, S, V, a);
+
+    public RgbaColor ToRgba() => ColorConversions.HsvToRgb(this);
+    public HslaColor ToHsla() => ColorConversions.HsvToHsl(this);
+
+    public bool Equals(HsvaColor other) => H == other.H && S == other.S && V == other.V && A == other.A;
+    public override bool Equals(object? obj) => obj is HsvaColor other && Equals(other);
+    public override int GetHashCode() => HashCode.Combine(H, S, V, A);
+    public static bool operator ==(HsvaColor a, HsvaColor b) => a.Equals(b);
+    public static bool operator !=(HsvaColor a, HsvaColor b) => !a.Equals(b);
+
+    public override string ToString() => $"hsva({H}, {S}, {V}, {A})";
+}

--- a/ColorPicker.Core/HueSaturationDisc.cs
+++ b/ColorPicker.Core/HueSaturationDisc.cs
@@ -1,0 +1,61 @@
+namespace ColorPicker.Core;
+
+/// <summary>
+/// HSL hue-saturation disc — the inner color disc of the ColorWheel control.
+/// The active area is a circle of radius 0.5 centered at (0.5, 0.5) of the
+/// unit square.
+///
+/// Encoding (matches the existing MAUI ColorDisc implementation 1:1):
+/// <list type="bullet">
+///   <item>angle  = (0.5 − hue) · 2π   (so hue 0 lands at angle π = unit-square left edge)</item>
+///   <item>radius = 0.5 · saturation   (saturation 1 → on the disc boundary)</item>
+/// </list>
+/// Hue is always wrapped to [0, 1] on read-back. Luminosity and alpha are
+/// passed through unchanged — they belong to the luminosity ring / alpha
+/// slider, not to this surface.
+///
+/// This type is stateless and the methods are pure.
+/// </summary>
+public sealed class HueSaturationDisc : IColorPickerArea
+{
+    public bool IsInActiveArea(UnitPoint point, HslaColor color)
+    {
+        var r = point.ToCentered().ToPolar().Radius;
+        return r <= 0.5f;
+    }
+
+    public UnitPoint FitToActiveArea(UnitPoint point, HslaColor color)
+    {
+        var polar = point.ToCentered().ToPolar();
+        if (polar.Radius > 0.5f)
+            polar = polar.WithRadius(0.5f);
+        return polar.ToCartesian().FromCentered();
+    }
+
+    public HslaColor UpdateColor(UnitPoint point, HslaColor color)
+    {
+        var fit = FitToActiveArea(point, color).ToCentered().ToPolar();
+        double hue = (Math.PI - fit.Angle) / (2.0 * Math.PI);
+        hue = WrapHue(hue);
+        double sat = fit.Radius * 2.0;
+        if (sat > 1.0) sat = 1.0;
+        if (sat < 0.0) sat = 0.0;
+        return color.WithH(hue).WithS(sat);
+    }
+
+    public UnitPoint ColorToPoint(HslaColor color)
+    {
+        double angle = (0.5 - color.H) * (2.0 * Math.PI);
+        double radius = 0.5 * Clamp01(color.S);
+        var centered = new PolarPoint((float)radius, (float)angle).ToCartesian();
+        return centered.FromCentered();
+    }
+
+    static double WrapHue(double h)
+    {
+        h %= 1.0;
+        return h < 0 ? h + 1.0 : h;
+    }
+
+    static double Clamp01(double v) => v < 0 ? 0 : v > 1 ? 1 : v;
+}

--- a/ColorPicker.Core/IColorPickerArea.cs
+++ b/ColorPicker.Core/IColorPickerArea.cs
@@ -1,0 +1,25 @@
+namespace ColorPicker.Core;
+
+/// <summary>
+/// The unified abstraction for every interactive picker shape — wheel, disc,
+/// luminosity ring, triangle, slider. All math is expressed on the unit
+/// square [0,1] × [0,1] and is independent of pixel size, rendering framework,
+/// and platform.
+///
+/// Implementations are expected to be pure (no hidden mutable state) so they
+/// can be exercised with deterministic unit tests.
+/// </summary>
+public interface IColorPickerArea
+{
+    /// <summary>True if <paramref name="point"/> falls inside this picker's interactive area.</summary>
+    bool IsInActiveArea(UnitPoint point, HslaColor color);
+
+    /// <summary>Project <paramref name="point"/> onto the interactive area (clamps out-of-bounds).</summary>
+    UnitPoint FitToActiveArea(UnitPoint point, HslaColor color);
+
+    /// <summary>Compute the new color that corresponds to <paramref name="point"/>, starting from <paramref name="color"/>.</summary>
+    HslaColor UpdateColor(UnitPoint point, HslaColor color);
+
+    /// <summary>Compute the unit-square location of the current <paramref name="color"/>'s indicator.</summary>
+    UnitPoint ColorToPoint(HslaColor color);
+}

--- a/ColorPicker.Core/LinearTrack.cs
+++ b/ColorPicker.Core/LinearTrack.cs
@@ -1,0 +1,26 @@
+namespace ColorPicker.Core;
+
+/// <summary>
+/// A 1-D track on the unit square, used by all linear sliders. The track
+/// occupies the full extent of the chosen axis; the cross-axis is fixed at
+/// 0.5. Values are normalized [0, 1] where 0 is the start of the track and
+/// 1 is the end.
+/// </summary>
+public readonly struct LinearTrack
+{
+    public bool Vertical { get; }
+
+    public LinearTrack(bool vertical) { Vertical = vertical; }
+
+    public double ValueAt(UnitPoint p)
+    {
+        double v = Vertical ? p.Y : p.X;
+        return v < 0 ? 0 : v > 1 ? 1 : v;
+    }
+
+    public UnitPoint PointFor(double value)
+    {
+        float v = value < 0 ? 0f : value > 1 ? 1f : (float)value;
+        return Vertical ? new UnitPoint(0.5f, v) : new UnitPoint(v, 0.5f);
+    }
+}

--- a/ColorPicker.Core/LuminosityRing.cs
+++ b/ColorPicker.Core/LuminosityRing.cs
@@ -1,0 +1,88 @@
+namespace ColorPicker.Core;
+
+/// <summary>
+/// Luminosity ring — the outer angular ring of the ColorWheel control. It
+/// lives at radius 0.5 of the unit square (centered at (0.5, 0.5)) and
+/// encodes L purely angularly.
+///
+/// Encoding (matches the existing MAUI ColorDisc 1:1):
+/// <list type="bullet">
+///   <item>L = 0  → 12 o'clock (top)</item>
+///   <item>L = 1  → 6 o'clock  (bottom)</item>
+///   <item>The point can be on either half (left or right) for any L in
+///   (0, 1). The side is a UI-only preference; the encoded L value is the
+///   same. Use <see cref="ColorToPoint(HslaColor, UnitPoint)"/> to preserve
+///   the side from a previous indicator location, otherwise the default
+///   right-hand side is used.</item>
+/// </list>
+///
+/// Hue, saturation, alpha are passed through unchanged.
+/// </summary>
+public sealed class LuminosityRing : IColorPickerArea
+{
+    /// <summary>Half-thickness (in unit-square units) used by hit testing.</summary>
+    public float HitTolerance { get; }
+
+    public LuminosityRing(float hitTolerance = 0.05f)
+    {
+        if (hitTolerance < 0f) throw new ArgumentOutOfRangeException(nameof(hitTolerance));
+        HitTolerance = hitTolerance;
+    }
+
+    public bool IsInActiveArea(UnitPoint point, HslaColor color)
+    {
+        var r = point.ToCentered().ToPolar().Radius;
+        return Math.Abs(r - 0.5f) <= HitTolerance;
+    }
+
+    public UnitPoint FitToActiveArea(UnitPoint point, HslaColor color)
+    {
+        var centered = point.ToCentered();
+        var polar = centered.ToPolar();
+        // Degenerate (exact center): default to right side.
+        if (polar.Radius == 0f)
+            return new PolarPoint(0.5f, 0f).ToCartesian().FromCentered();
+        return polar.WithRadius(0.5f).ToCartesian().FromCentered();
+    }
+
+    public HslaColor UpdateColor(UnitPoint point, HslaColor color)
+    {
+        var polar = point.ToCentered().ToPolar();
+        // Shift so 12 o'clock = 0, then |angle| / π = L (mirrored across vertical axis).
+        double shifted = polar.Angle + Math.PI / 2.0;
+        // Re-wrap into [-π, π] using atan2 of sin/cos (matches the MAUI
+        // FromPolar→ToPolar round-trip).
+        shifted = Math.Atan2(Math.Sin(shifted), Math.Cos(shifted));
+        double l = Math.Abs(shifted) / Math.PI;
+        if (l > 1.0) l = 1.0;
+        if (l < 0.0) l = 0.0;
+        return color.WithL(l);
+    }
+
+    public UnitPoint ColorToPoint(HslaColor color) => ColorToPoint(color, sign: +1);
+
+    /// <summary>
+    /// Encode color using <paramref name="previousPoint"/> to determine
+    /// which half of the ring the indicator should be placed on.
+    /// </summary>
+    public UnitPoint ColorToPoint(HslaColor color, UnitPoint previousPoint)
+    {
+        var prevPolar = previousPoint.ToCentered().ToPolar();
+        // Re-wrap to [-π, π] after the shift; this matches MAUI's
+        // FromPolar→ToPolar round-trip and is what makes left/right
+        // detection correct at the angular discontinuity.
+        double shifted = prevPolar.Angle - Math.PI / 2.0;
+        shifted = Math.Atan2(Math.Sin(shifted), Math.Cos(shifted));
+        int sign = shifted <= 0 ? +1 : -1;
+        return ColorToPoint(color, sign);
+    }
+
+    UnitPoint ColorToPoint(HslaColor color, int sign)
+    {
+        double l = color.L;
+        if (l < 0) l = 0;
+        if (l > 1) l = 1;
+        double angle = l * Math.PI * sign - Math.PI / 2.0;
+        return new PolarPoint(0.5f, (float)angle).ToCartesian().FromCentered();
+    }
+}

--- a/ColorPicker.Core/PolarPoint.cs
+++ b/ColorPicker.Core/PolarPoint.cs
@@ -1,0 +1,50 @@
+namespace ColorPicker.Core;
+
+/// <summary>
+/// Polar coordinates with the angle normalized to [-π, π] on construction.
+/// </summary>
+public readonly struct PolarPoint : IEquatable<PolarPoint>
+{
+    public float Radius { get; }
+
+    /// <summary>Angle in radians, normalized to [-π, π].</summary>
+    public float Angle { get; }
+
+    public PolarPoint(float radius, float angle)
+    {
+        Radius = radius;
+        Angle = Normalize(angle);
+    }
+
+    /// <summary>Build a polar point from cartesian coordinates (origin at 0,0).</summary>
+    public static PolarPoint FromCartesian(float x, float y)
+    {
+        var r = (float)Math.Sqrt((x * x) + (y * y));
+        var a = (float)Math.Atan2(y, x);
+        return new PolarPoint(r, a);
+    }
+
+    public PolarPoint WithRadius(float radius) => new(radius, Angle);
+    public PolarPoint WithAngle(float angle) => new(Radius, angle);
+    public PolarPoint AddAngle(float delta) => new(Radius, Angle + delta);
+    public PolarPoint AddRadius(float delta) => new(Radius + delta, Angle);
+
+    /// <summary>Convert back to cartesian. Origin is (0,0); caller is responsible for any centering.</summary>
+    public UnitPoint ToCartesian()
+    {
+        var x = (float)(Radius * Math.Cos(Angle));
+        var y = (float)(Radius * Math.Sin(Angle));
+        return new UnitPoint(x, y);
+    }
+
+    static float Normalize(float angle) =>
+        (float)Math.Atan2(Math.Sin(angle), Math.Cos(angle));
+
+    public bool Equals(PolarPoint other) => Radius == other.Radius && Angle == other.Angle;
+    public override bool Equals(object? obj) => obj is PolarPoint other && Equals(other);
+    public override int GetHashCode() => HashCode.Combine(Radius, Angle);
+    public static bool operator ==(PolarPoint a, PolarPoint b) => a.Equals(b);
+    public static bool operator !=(PolarPoint a, PolarPoint b) => !a.Equals(b);
+
+    public override string ToString() => $"R: {Radius}; A: {Angle}";
+}

--- a/ColorPicker.Core/RgbaColor.cs
+++ b/ColorPicker.Core/RgbaColor.cs
@@ -1,0 +1,31 @@
+namespace ColorPicker.Core;
+
+/// <summary>
+/// RGBA color with each channel in [0, 1].
+/// </summary>
+public readonly struct RgbaColor : IEquatable<RgbaColor>
+{
+    public double R { get; }
+    public double G { get; }
+    public double B { get; }
+    public double A { get; }
+
+    public RgbaColor(double r, double g, double b, double a = 1.0)
+    {
+        R = r;
+        G = g;
+        B = b;
+        A = a;
+    }
+
+    public HslaColor ToHsla() => ColorConversions.RgbToHsl(this);
+    public HsvaColor ToHsva() => ColorConversions.RgbToHsv(this);
+
+    public bool Equals(RgbaColor other) => R == other.R && G == other.G && B == other.B && A == other.A;
+    public override bool Equals(object? obj) => obj is RgbaColor other && Equals(other);
+    public override int GetHashCode() => HashCode.Combine(R, G, B, A);
+    public static bool operator ==(RgbaColor a, RgbaColor b) => a.Equals(b);
+    public static bool operator !=(RgbaColor a, RgbaColor b) => !a.Equals(b);
+
+    public override string ToString() => $"rgba({R}, {G}, {B}, {A})";
+}

--- a/ColorPicker.Core/UnitPoint.cs
+++ b/ColorPicker.Core/UnitPoint.cs
@@ -1,0 +1,43 @@
+namespace ColorPicker.Core;
+
+/// <summary>
+/// A 2D point on the unit square [0, 1] × [0, 1] used as the abstract
+/// coordinate space for all color-picker math. Callers (rendering layer)
+/// map between pixel coordinates and unit coordinates.
+///
+/// Values are not clamped on construction so that out-of-range inputs can
+/// be detected by hit-testing and then projected back with
+/// <c>IColorPickerArea.FitToActiveArea</c>.
+/// </summary>
+public readonly struct UnitPoint : IEquatable<UnitPoint>
+{
+    public float X { get; }
+    public float Y { get; }
+
+    public UnitPoint(float x, float y)
+    {
+        X = x;
+        Y = y;
+    }
+
+    public UnitPoint WithX(float x) => new(x, Y);
+    public UnitPoint WithY(float y) => new(X, y);
+
+    public UnitPoint Translate(float dx, float dy) => new(X + dx, Y + dy);
+
+    /// <summary>Shift this point so the unit-square center (0.5, 0.5) becomes the origin.</summary>
+    public UnitPoint ToCentered() => new(X - 0.5f, Y - 0.5f);
+
+    /// <summary>Shift a centered point (origin at center) back to unit-square coordinates.</summary>
+    public UnitPoint FromCentered() => new(X + 0.5f, Y + 0.5f);
+
+    public PolarPoint ToPolar() => PolarPoint.FromCartesian(X, Y);
+
+    public bool Equals(UnitPoint other) => X == other.X && Y == other.Y;
+    public override bool Equals(object? obj) => obj is UnitPoint other && Equals(other);
+    public override int GetHashCode() => HashCode.Combine(X, Y);
+    public static bool operator ==(UnitPoint a, UnitPoint b) => a.Equals(b);
+    public static bool operator !=(UnitPoint a, UnitPoint b) => !a.Equals(b);
+
+    public override string ToString() => $"({X}, {Y})";
+}

--- a/ColorPicker.Maui.sln
+++ b/ColorPicker.Maui.sln
@@ -9,6 +9,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ColorPicker", "ColorPicker\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ColorPicker.UITests", "ColorPicker.UITests\ColorPicker.UITests.csproj", "{E789D919-48BE-4B4E-80F1-8492DFA39ADC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ColorPicker.Core", "ColorPicker.Core\ColorPicker.Core.csproj", "{F64F82E5-DC91-468B-A4F6-F0CB520BDDB6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ColorPicker.Core.Tests", "ColorPicker.Core.Tests\ColorPicker.Core.Tests.csproj", "{1B53F3B2-A2AD-4E24-8D93-FBBCFCC6993F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +49,22 @@ Global
 		{E789D919-48BE-4B4E-80F1-8492DFA39ADC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E789D919-48BE-4B4E-80F1-8492DFA39ADC}.Release|x64.ActiveCfg = Release|Any CPU
 		{E789D919-48BE-4B4E-80F1-8492DFA39ADC}.Release|x64.Build.0 = Release|Any CPU
+		{F64F82E5-DC91-468B-A4F6-F0CB520BDDB6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F64F82E5-DC91-468B-A4F6-F0CB520BDDB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F64F82E5-DC91-468B-A4F6-F0CB520BDDB6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F64F82E5-DC91-468B-A4F6-F0CB520BDDB6}.Debug|x64.Build.0 = Debug|Any CPU
+		{F64F82E5-DC91-468B-A4F6-F0CB520BDDB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F64F82E5-DC91-468B-A4F6-F0CB520BDDB6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F64F82E5-DC91-468B-A4F6-F0CB520BDDB6}.Release|x64.ActiveCfg = Release|Any CPU
+		{F64F82E5-DC91-468B-A4F6-F0CB520BDDB6}.Release|x64.Build.0 = Release|Any CPU
+		{1B53F3B2-A2AD-4E24-8D93-FBBCFCC6993F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B53F3B2-A2AD-4E24-8D93-FBBCFCC6993F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1B53F3B2-A2AD-4E24-8D93-FBBCFCC6993F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1B53F3B2-A2AD-4E24-8D93-FBBCFCC6993F}.Debug|x64.Build.0 = Debug|Any CPU
+		{1B53F3B2-A2AD-4E24-8D93-FBBCFCC6993F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1B53F3B2-A2AD-4E24-8D93-FBBCFCC6993F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1B53F3B2-A2AD-4E24-8D93-FBBCFCC6993F}.Release|x64.ActiveCfg = Release|Any CPU
+		{1B53F3B2-A2AD-4E24-8D93-FBBCFCC6993F}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Phase 0 of the math/render split. Scaffolding only — no behavior changes to the MAUI library.

## What's in
- **`ColorPicker.Core`** — netstandard2.0 + net8.0, zero deps. Types: `UnitPoint`, `PolarPoint` (immutable readonly structs), `HslaColor`, `HsvaColor`, `RgbaColor`, `ColorConversions`, and the unified `IColorPickerArea` interface every shape will implement.
- **`ColorPicker.Core.Tests`** — xUnit, 51 tests passing locally in ~30 ms.
- **New CI job** `Core Unit Tests` (ubuntu, no MAUI workload needed).

## Design notes vs the old Xamarin attempt
Borrowed the unit-square abstraction and 4-method `IColorPickerArea` interface from [vpapenko/ColorPicker@feture/AbstractCore](https://github.com/vpapenko/ColorPicker/tree/feture/AbstractCore), with intentional fixes:
- No Xamarin.Forms / framework dependency — `HslaColor` is our own type.
- No ColorMineStandard — HSL↔HSV brought in-house (standard formulas).
- Immutable readonly structs (the old `AbstractPoint` was mutable).
- No hidden mutable state in picker classes (old code stored `lastHue` / `IsLeftSide` — those become caller responsibility).
- Spelling fixes: Area not Aria, Horizontal not Horisontal, angle not angel.

## Next
Phase 1 will port the first picker shape (likely the wheel/disc) to Core with characterization tests against the existing MAUI behavior.

> Note: the new `Core Unit Tests` CI context will need to be added to the `main` branch protection ruleset after this PR merges (GitHub won't recognize the context until it has run at least once).