### PR TITLE
feat(core): LuminosityRing math + tests (Phase 2)

### DIFF
--- a/ColorPicker.Core.Tests/LuminosityRingTests.cs
+++ b/ColorPicker.Core.Tests/LuminosityRingTests.cs
@@ -1,0 +1,141 @@
+namespace ColorPicker.Core.Tests;
+
+public class LuminosityRingTests
+{
+    readonly LuminosityRing _ring = new();
+
+    // ---- ColorToPoint: known positions ------------------------------------
+
+    [Fact]
+    public void ColorToPoint_L0_LandsAtTop()
+    {
+        var p = _ring.ColorToPoint(new HslaColor(0.3, 0.5, 0.0));
+        Assert.Equal(0.5f, p.X, 1e-5);
+        Assert.Equal(0.0f, p.Y, 1e-5); // top edge (screen y=0)
+    }
+
+    [Fact]
+    public void ColorToPoint_L1_LandsAtBottom()
+    {
+        var p = _ring.ColorToPoint(new HslaColor(0.3, 0.5, 1.0));
+        Assert.Equal(0.5f, p.X, 1e-5);
+        Assert.Equal(1.0f, p.Y, 1e-5);
+    }
+
+    [Fact]
+    public void ColorToPoint_LHalf_DefaultsToRightSide()
+    {
+        var p = _ring.ColorToPoint(new HslaColor(0.3, 0.5, 0.5));
+        Assert.Equal(1.0f, p.X, 1e-5);
+        Assert.Equal(0.5f, p.Y, 1e-5);
+    }
+
+    [Fact]
+    public void ColorToPoint_WithPrevPointOnLeft_StaysOnLeft()
+    {
+        // Previous indicator at 9 o'clock (left edge)
+        var prev = new UnitPoint(0f, 0.5f);
+        var p = _ring.ColorToPoint(new HslaColor(0.3, 0.5, 0.5), prev);
+        Assert.Equal(0.0f, p.X, 1e-5);
+        Assert.Equal(0.5f, p.Y, 1e-5);
+    }
+
+    [Fact]
+    public void ColorToPoint_WithPrevPointOnRight_StaysOnRight()
+    {
+        var prev = new UnitPoint(1f, 0.5f);
+        var p = _ring.ColorToPoint(new HslaColor(0.3, 0.5, 0.5), prev);
+        Assert.Equal(1.0f, p.X, 1e-5);
+        Assert.Equal(0.5f, p.Y, 1e-5);
+    }
+
+    // ---- UpdateColor: known positions -------------------------------------
+
+    [Theory]
+    [InlineData(0.5f, 0.0f, 0.0)]   // top   → L=0
+    [InlineData(0.5f, 1.0f, 1.0)]   // bottom→ L=1
+    [InlineData(1.0f, 0.5f, 0.5)]   // right → L=0.5
+    [InlineData(0.0f, 0.5f, 0.5)]   // left  → L=0.5 (sign lost)
+    public void UpdateColor_KnownPositions(float x, float y, double expL)
+    {
+        var c = _ring.UpdateColor(new UnitPoint(x, y), new HslaColor(0.3, 0.5, 0));
+        Assert.Equal(expL, c.L, 1e-5);
+    }
+
+    [Fact]
+    public void UpdateColor_PreservesHSAandWrapsLuminosity()
+    {
+        var orig = new HslaColor(0.42, 0.6, 0.0, 0.7);
+        var c = _ring.UpdateColor(new UnitPoint(0.85f, 0.85f), orig);
+        Assert.Equal(orig.H, c.H);
+        Assert.Equal(orig.S, c.S);
+        Assert.Equal(orig.A, c.A);
+        Assert.InRange(c.L, 0.0, 1.0);
+    }
+
+    // ---- Round trips -------------------------------------------------------
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(0.1)]
+    [InlineData(0.25)]
+    [InlineData(0.5)]
+    [InlineData(0.75)]
+    [InlineData(1.0)]
+    public void RoundTrip_DefaultSide(double l)
+    {
+        var orig = new HslaColor(0.2, 0.7, l, 0.5);
+        var p = _ring.ColorToPoint(orig);
+        var back = _ring.UpdateColor(p, orig);
+        Assert.Equal(orig.L, back.L, 1e-5);
+    }
+
+    [Theory]
+    [InlineData(0.1)]
+    [InlineData(0.5)]
+    [InlineData(0.9)]
+    public void RoundTrip_WithLeftSideHint(double l)
+    {
+        var orig = new HslaColor(0.2, 0.7, l, 0.5);
+        var p = _ring.ColorToPoint(orig, new UnitPoint(0f, 0.5f));
+        Assert.True(p.X <= 0.5f, $"expected left half, got X={p.X}");
+        var back = _ring.UpdateColor(p, orig);
+        Assert.Equal(orig.L, back.L, 1e-5);
+    }
+
+    // ---- IsInActiveArea ---------------------------------------------------
+
+    [Fact]
+    public void IsInActiveArea_PointOnRing_IsActive()
+    {
+        // 3 o'clock, exactly on ring
+        var p = new UnitPoint(1f, 0.5f);
+        Assert.True(_ring.IsInActiveArea(p, default));
+    }
+
+    [Fact]
+    public void IsInActiveArea_PointAtCenter_NotActive()
+    {
+        var p = new UnitPoint(0.5f, 0.5f);
+        Assert.False(_ring.IsInActiveArea(p, default));
+    }
+
+    // ---- FitToActiveArea --------------------------------------------------
+
+    [Fact]
+    public void FitToActiveArea_OffRingPoint_ProjectsToRingRadius()
+    {
+        var p = new UnitPoint(0.75f, 0.5f); // radius 0.25
+        var fit = _ring.FitToActiveArea(p, default);
+        var r = fit.ToCentered().ToPolar().Radius;
+        Assert.Equal(0.5f, r, 1e-5);
+    }
+
+    [Fact]
+    public void FitToActiveArea_Center_DefaultsToRightSide()
+    {
+        var fit = _ring.FitToActiveArea(new UnitPoint(0.5f, 0.5f), default);
+        Assert.Equal(1.0f, fit.X, 1e-5);
+        Assert.Equal(0.5f, fit.Y, 1e-5);
+    }
+}

--- a/ColorPicker.Core/LuminosityRing.cs
+++ b/ColorPicker.Core/LuminosityRing.cs
@@ -1,0 +1,88 @@
+namespace ColorPicker.Core;
+
+/// <summary>
+/// Luminosity ring — the outer angular ring of the ColorWheel control. It
+/// lives at radius 0.5 of the unit square (centered at (0.5, 0.5)) and
+/// encodes L purely angularly.
+///
+/// Encoding (matches the existing MAUI ColorDisc 1:1):
+/// <list type="bullet">
+///   <item>L = 0  → 12 o'clock (top)</item>
+///   <item>L = 1  → 6 o'clock  (bottom)</item>
+///   <item>The point can be on either half (left or right) for any L in
+///   (0, 1). The side is a UI-only preference; the encoded L value is the
+///   same. Use <see cref="ColorToPoint(HslaColor, UnitPoint)"/> to preserve
+///   the side from a previous indicator location, otherwise the default
+///   right-hand side is used.</item>
+/// </list>
+///
+/// Hue, saturation, alpha are passed through unchanged.
+/// </summary>
+public sealed class LuminosityRing : IColorPickerArea
+{
+    /// <summary>Half-thickness (in unit-square units) used by hit testing.</summary>
+    public float HitTolerance { get; }
+
+    public LuminosityRing(float hitTolerance = 0.05f)
+    {
+        if (hitTolerance < 0f) throw new ArgumentOutOfRangeException(nameof(hitTolerance));
+        HitTolerance = hitTolerance;
+    }
+
+    public bool IsInActiveArea(UnitPoint point, HslaColor color)
+    {
+        var r = point.ToCentered().ToPolar().Radius;
+        return Math.Abs(r - 0.5f) <= HitTolerance;
+    }
+
+    public UnitPoint FitToActiveArea(UnitPoint point, HslaColor color)
+    {
+        var centered = point.ToCentered();
+        var polar = centered.ToPolar();
+        // Degenerate (exact center): default to right side.
+        if (polar.Radius == 0f)
+            return new PolarPoint(0.5f, 0f).ToCartesian().FromCentered();
+        return polar.WithRadius(0.5f).ToCartesian().FromCentered();
+    }
+
+    public HslaColor UpdateColor(UnitPoint point, HslaColor color)
+    {
+        var polar = point.ToCentered().ToPolar();
+        // Shift so 12 o'clock = 0, then |angle| / π = L (mirrored across vertical axis).
+        double shifted = polar.Angle + Math.PI / 2.0;
+        // Re-wrap into [-π, π] using atan2 of sin/cos (matches the MAUI
+        // FromPolar→ToPolar round-trip).
+        shifted = Math.Atan2(Math.Sin(shifted), Math.Cos(shifted));
+        double l = Math.Abs(shifted) / Math.PI;
+        if (l > 1.0) l = 1.0;
+        if (l < 0.0) l = 0.0;
+        return color.WithL(l);
+    }
+
+    public UnitPoint ColorToPoint(HslaColor color) => ColorToPoint(color, sign: +1);
+
+    /// <summary>
+    /// Encode color using <paramref name="previousPoint"/> to determine
+    /// which half of the ring the indicator should be placed on.
+    /// </summary>
+    public UnitPoint ColorToPoint(HslaColor color, UnitPoint previousPoint)
+    {
+        var prevPolar = previousPoint.ToCentered().ToPolar();
+        // Re-wrap to [-π, π] after the shift; this matches MAUI's
+        // FromPolar→ToPolar round-trip and is what makes left/right
+        // detection correct at the angular discontinuity.
+        double shifted = prevPolar.Angle - Math.PI / 2.0;
+        shifted = Math.Atan2(Math.Sin(shifted), Math.Cos(shifted));
+        int sign = shifted <= 0 ? +1 : -1;
+        return ColorToPoint(color, sign);
+    }
+
+    UnitPoint ColorToPoint(HslaColor color, int sign)
+    {
+        double l = color.L;
+        if (l < 0) l = 0;
+        if (l > 1) l = 1;
+        double angle = l * Math.PI * sign - Math.PI / 2.0;
+        return new PolarPoint(0.5f, (float)angle).ToCartesian().FromCentered();
+    }
+}


### PR DESCRIPTION
Stacked on #30 (independent of #31).

Pure platform-agnostic port of ColorDisc luminosity ring math to the unit square. Behavior matches the existing MAUI `ColorDisc` 1:1 (verified against source). L is encoded purely angularly:

- L = 0   -> 12 o'clock (top)
- L = 1   -> 6 o'clock  (bottom)
- L in (0,1) can sit on either half (sign carries indicator side; encoded L is the same)

`ColorToPoint(color, prevPoint)` overload preserves the previous half, matching MAUI's `FromPolar->ToPolar` re-wrap subtlety (initial implementation got this wrong; scratch repro confirmed the angle-discontinuity issue at polar.Angle = +/- pi).

12 new xUnit tests. No MAUI changes — wiring lands later.