### PR TITLE
feat(core): LinearTrack + HSL channel sliders (Phase 4)

### DIFF
--- a/ColorPicker.Core.Tests/HslChannelSlidersTests.cs
+++ b/ColorPicker.Core.Tests/HslChannelSlidersTests.cs
@@ -1,0 +1,102 @@
+namespace ColorPicker.Core.Tests;
+
+public class HslChannelSlidersTests
+{
+    static readonly HslaColor Base = new(0.25, 0.6, 0.4, 0.8);
+
+    [Fact]
+    public void HueSlider_RoundTrip()
+    {
+        var s = new HueSlider();
+        var p = s.ColorToPoint(Base);
+        Assert.Equal(0.25f, p.X, 1e-5);
+        Assert.Equal(0.5f,  p.Y, 1e-5);
+
+        var c = s.UpdateColor(new UnitPoint(0.75f, 0.5f), Base);
+        Assert.Equal(0.75, c.H, 1e-5);
+        Assert.Equal(Base.S, c.S);
+        Assert.Equal(Base.L, c.L);
+        Assert.Equal(Base.A, c.A);
+    }
+
+    [Fact]
+    public void SaturationSlider_ReadsSaturation()
+    {
+        var s = new SaturationSlider();
+        Assert.Equal(0.6f, s.ColorToPoint(Base).X, 1e-5);
+        var c = s.UpdateColor(new UnitPoint(0.2f, 0.5f), Base);
+        Assert.Equal(0.2, c.S, 1e-5);
+        Assert.Equal(Base.H, c.H);
+    }
+
+    [Fact]
+    public void LuminositySlider_ReadsLuminosity()
+    {
+        var s = new LuminositySlider();
+        Assert.Equal(0.4f, s.ColorToPoint(Base).X, 1e-5);
+        var c = s.UpdateColor(new UnitPoint(0.9f, 0.5f), Base);
+        Assert.Equal(0.9, c.L, 1e-5);
+    }
+
+    [Fact]
+    public void AlphaSlider_ReadsAlpha()
+    {
+        var s = new AlphaSlider();
+        Assert.Equal(0.8f, s.ColorToPoint(Base).X, 1e-5);
+        var c = s.UpdateColor(new UnitPoint(0.1f, 0.5f), Base);
+        Assert.Equal(0.1, c.A, 1e-5);
+    }
+
+    [Fact]
+    public void VerticalSlider_UsesYAxis()
+    {
+        var s = new HueSlider(vertical: true);
+        var p = s.ColorToPoint(Base);
+        Assert.Equal(0.5f,  p.X, 1e-5);
+        Assert.Equal(0.25f, p.Y, 1e-5);
+        var c = s.UpdateColor(new UnitPoint(0.5f, 0.7f), Base);
+        Assert.Equal(0.7, c.H, 1e-5);
+    }
+
+    [Fact]
+    public void FitToActiveArea_SnapsCrossAxisToCenter()
+    {
+        var s = new HueSlider();
+        var p = s.FitToActiveArea(new UnitPoint(0.3f, 0.9f), Base);
+        Assert.Equal(0.3f, p.X, 1e-5);
+        Assert.Equal(0.5f, p.Y, 1e-5);
+    }
+
+    [Fact]
+    public void IsInActiveArea_AlwaysTrue()
+    {
+        var s = new HueSlider();
+        Assert.True(s.IsInActiveArea(new UnitPoint(0f, 0f), Base));
+        Assert.True(s.IsInActiveArea(new UnitPoint(2f, -3f), Base));
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(0.33)]
+    [InlineData(0.67)]
+    [InlineData(1.0)]
+    public void AllChannelSliders_RoundTrip(double v)
+    {
+        var c = new HslaColor(v, v, v, v);
+        foreach (var s in new HslChannelSlider[]
+        {
+            new HueSlider(), new SaturationSlider(),
+            new LuminositySlider(), new AlphaSlider(),
+        })
+        {
+            var p = s.ColorToPoint(c);
+            var back = s.UpdateColor(p, c);
+            // each slider mutates its own channel; the round-trip leaves
+            // every other channel untouched, so back == c.
+            Assert.Equal(c.H, back.H, 1e-6);
+            Assert.Equal(c.S, back.S, 1e-6);
+            Assert.Equal(c.L, back.L, 1e-6);
+            Assert.Equal(c.A, back.A, 1e-6);
+        }
+    }
+}

--- a/ColorPicker.Core.Tests/LinearTrackTests.cs
+++ b/ColorPicker.Core.Tests/LinearTrackTests.cs
@@ -1,0 +1,49 @@
+namespace ColorPicker.Core.Tests;
+
+public class LinearTrackTests
+{
+    [Theory]
+    [InlineData(false, 0.0f, 0.5f, 0.0)]
+    [InlineData(false, 0.5f, 0.5f, 0.5)]
+    [InlineData(false, 1.0f, 0.5f, 1.0)]
+    [InlineData(true,  0.5f, 0.0f, 0.0)]
+    [InlineData(true,  0.5f, 0.5f, 0.5)]
+    [InlineData(true,  0.5f, 1.0f, 1.0)]
+    public void ValueAt_KnownPositions(bool vertical, float x, float y, double expected)
+    {
+        var t = new LinearTrack(vertical);
+        Assert.Equal(expected, t.ValueAt(new UnitPoint(x, y)), 1e-6);
+    }
+
+    [Theory]
+    [InlineData(false, 0.0, 0.0f, 0.5f)]
+    [InlineData(false, 0.5, 0.5f, 0.5f)]
+    [InlineData(false, 1.0, 1.0f, 0.5f)]
+    [InlineData(true,  0.5, 0.5f, 0.5f)]
+    public void PointFor_KnownValues(bool vertical, double v, float ex, float ey)
+    {
+        var t = new LinearTrack(vertical);
+        var p = t.PointFor(v);
+        Assert.Equal(ex, p.X, 1e-5);
+        Assert.Equal(ey, p.Y, 1e-5);
+    }
+
+    [Theory]
+    [InlineData(-1.0, 0.0)]
+    [InlineData( 0.5, 0.5)]
+    [InlineData( 2.0, 1.0)]
+    public void PointFor_ClampsOutOfRange(double v, double expected)
+    {
+        var t = new LinearTrack(false);
+        Assert.Equal(expected, t.PointFor(v).X, 1e-6);
+    }
+
+    [Theory]
+    [InlineData(-0.5f, 0.0)]
+    [InlineData( 1.5f, 1.0)]
+    public void ValueAt_ClampsOutOfRange(float x, double expected)
+    {
+        var t = new LinearTrack(false);
+        Assert.Equal(expected, t.ValueAt(new UnitPoint(x, 0.5f)), 1e-6);
+    }
+}

--- a/ColorPicker.Core/HslChannelSliders.cs
+++ b/ColorPicker.Core/HslChannelSliders.cs
@@ -1,0 +1,58 @@
+namespace ColorPicker.Core;
+
+/// <summary>
+/// Base class for HSL channel sliders (Hue / Saturation / Luminosity /
+/// Alpha). Each subclass plugs in a read/write pair for its specific
+/// channel; the geometry comes from <see cref="LinearTrack"/>.
+///
+/// All channel sliders treat the entire unit square as their active area —
+/// any tap is mapped to the track via <see cref="FitToActiveArea"/>. (Pixel
+/// thickness / hit tolerance lives in the render layer, not here.)
+/// </summary>
+public abstract class HslChannelSlider : IColorPickerArea
+{
+    public LinearTrack Track { get; }
+
+    protected HslChannelSlider(LinearTrack track) { Track = track; }
+
+    public bool IsInActiveArea(UnitPoint point, HslaColor color) => true;
+
+    public UnitPoint FitToActiveArea(UnitPoint point, HslaColor color)
+        => Track.PointFor(Track.ValueAt(point));
+
+    public HslaColor UpdateColor(UnitPoint point, HslaColor color)
+        => Write(color, Track.ValueAt(point));
+
+    public UnitPoint ColorToPoint(HslaColor color) => Track.PointFor(Read(color));
+
+    protected abstract double Read(HslaColor color);
+    protected abstract HslaColor Write(HslaColor color, double value);
+}
+
+public sealed class HueSlider : HslChannelSlider
+{
+    public HueSlider(bool vertical = false) : base(new LinearTrack(vertical)) { }
+    protected override double Read(HslaColor c) => c.H;
+    protected override HslaColor Write(HslaColor c, double v) => c.WithH(v);
+}
+
+public sealed class SaturationSlider : HslChannelSlider
+{
+    public SaturationSlider(bool vertical = false) : base(new LinearTrack(vertical)) { }
+    protected override double Read(HslaColor c) => c.S;
+    protected override HslaColor Write(HslaColor c, double v) => c.WithS(v);
+}
+
+public sealed class LuminositySlider : HslChannelSlider
+{
+    public LuminositySlider(bool vertical = false) : base(new LinearTrack(vertical)) { }
+    protected override double Read(HslaColor c) => c.L;
+    protected override HslaColor Write(HslaColor c, double v) => c.WithL(v);
+}
+
+public sealed class AlphaSlider : HslChannelSlider
+{
+    public AlphaSlider(bool vertical = false) : base(new LinearTrack(vertical)) { }
+    protected override double Read(HslaColor c) => c.A;
+    protected override HslaColor Write(HslaColor c, double v) => c.WithA(v);
+}

--- a/ColorPicker.Core/LinearTrack.cs
+++ b/ColorPicker.Core/LinearTrack.cs
@@ -1,0 +1,26 @@
+namespace ColorPicker.Core;
+
+/// <summary>
+/// A 1-D track on the unit square, used by all linear sliders. The track
+/// occupies the full extent of the chosen axis; the cross-axis is fixed at
+/// 0.5. Values are normalized [0, 1] where 0 is the start of the track and
+/// 1 is the end.
+/// </summary>
+public readonly struct LinearTrack
+{
+    public bool Vertical { get; }
+
+    public LinearTrack(bool vertical) { Vertical = vertical; }
+
+    public double ValueAt(UnitPoint p)
+    {
+        double v = Vertical ? p.Y : p.X;
+        return v < 0 ? 0 : v > 1 ? 1 : v;
+    }
+
+    public UnitPoint PointFor(double value)
+    {
+        float v = value < 0 ? 0f : value > 1 ? 1f : (float)value;
+        return Vertical ? new UnitPoint(0.5f, v) : new UnitPoint(v, 0.5f);
+    }
+}


### PR DESCRIPTION
Stacked on #30.

Pure platform-agnostic 1-D mapping for sliders, plus four concrete HSL channel sliders (Hue, Saturation, Luminosity, Alpha). Each implements `IColorPickerArea` through a shared `HslChannelSlider` base. Track geometry lives in `LinearTrack` (the only shape-agnostic geometry primitive needed for sliders).

37 new xUnit tests. RGB channel sliders deferred to a follow-up so they can route through `ColorConversions` carefully (HSL<->RGB round-trip is lossy for grayscale).

Note: branch name says 'triangle' for historical reasons (was originally meant for triangle); content is sliders. Triangle port (with rotation + barycentric math + mutable _lastHue state) is deferred — it's the highest-risk port and deserves user input on how to model the rotation-state separation.