### PR TITLE
feat(core): Triangle (SV + Hue Ring) + RGB channel sliders

### DIFF
--- a/ColorPicker.Core.Tests/HueRingTests.cs
+++ b/ColorPicker.Core.Tests/HueRingTests.cs
@@ -1,0 +1,57 @@
+namespace ColorPicker.Core.Tests;
+
+public class HueRingTests
+{
+    readonly HueRing _ring = new();
+
+    [Theory]
+    [InlineData(0.0,  0.0f, 0.5f)]   // hue 0   → left
+    [InlineData(0.25, 0.5f, 1.0f)]   // hue 0.25→ bottom
+    [InlineData(0.5,  1.0f, 0.5f)]   // hue 0.5 → right
+    [InlineData(0.75, 0.5f, 0.0f)]   // hue 0.75→ top
+    public void ColorToPoint_KnownHues(double hue, float ex, float ey)
+    {
+        var p = _ring.ColorToPoint(new HslaColor(hue, 0.5, 0.5));
+        Assert.Equal(ex, p.X, 1e-5);
+        Assert.Equal(ey, p.Y, 1e-5);
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(0.13)]
+    [InlineData(0.5)]
+    [InlineData(0.99)]
+    public void RoundTrip(double hue)
+    {
+        var orig = new HslaColor(hue, 0.6, 0.4, 0.7);
+        var p = _ring.ColorToPoint(orig);
+        var back = _ring.UpdateColor(p, orig);
+        double dh = Math.Abs(orig.H - back.H);
+        dh = Math.Min(dh, 1.0 - dh);
+        Assert.True(dh < 1e-5);
+        Assert.Equal(orig.S, back.S);
+        Assert.Equal(orig.L, back.L);
+        Assert.Equal(orig.A, back.A);
+    }
+
+    [Fact]
+    public void IsInActiveArea_OnRing() =>
+        Assert.True(_ring.IsInActiveArea(new UnitPoint(1f, 0.5f), default));
+
+    [Fact]
+    public void IsInActiveArea_AtCenter_False() =>
+        Assert.False(_ring.IsInActiveArea(new UnitPoint(0.5f, 0.5f), default));
+
+    [Fact]
+    public void UpdateColor_AllAngles_ReturnHueInUnitInterval()
+    {
+        var c = new HslaColor(0, 0.5, 0.5);
+        for (int i = 0; i < 360; i++)
+        {
+            double ang = i * Math.PI / 180.0;
+            var p = new PolarPoint(0.4f, (float)ang).ToCartesian().FromCentered();
+            var result = _ring.UpdateColor(p, c);
+            Assert.InRange(result.H, 0.0, 1.0);
+        }
+    }
+}

--- a/ColorPicker.Core.Tests/MauiTriangleReference.cs
+++ b/ColorPicker.Core.Tests/MauiTriangleReference.cs
@@ -1,0 +1,81 @@
+namespace ColorPicker.Core.Tests;
+
+/// <summary>
+/// Reference implementation: mirrors MAUI ColorTriangleArea pixel-space math
+/// verbatim. Used to cross-validate the unit-square port in
+/// SaturationValueTriangle. If MAUI changes, this file must change too —
+/// it is the contract we are porting.
+/// </summary>
+static class MauiTriangleReference
+{
+    public const float TriangleHeight = 1.5000001F;
+    public const float TriangleSide = 0.8660244F;
+    public const float TriangleVerticalOffset = 0.5000001F;
+
+    // Pixel-space encode (analogous to ColorTriangleArea.UpdateLocations).
+    // Returns pixel point centered on (canvasRadius, canvasRadius).
+    public static (float x, float y) EncodeSvPixel(
+        double s, double v, double hue, float canvasRadius, float svRadius, bool rotateByHue)
+    {
+        double lumX = TriangleSide * (1 - 2 * s);
+        double lumY = TriangleHeight;
+        double r = Math.Sqrt(lumX * lumX + lumY * lumY) * v;
+        double a = Math.Atan2(lumY, lumX);
+
+        double x = r * Math.Cos(a);
+        double y = r * Math.Sin(a);
+        x = -x;
+        y -= 1;
+        x *= svRadius;
+        y *= svRadius;
+
+        double rotR = Math.Sqrt(x * x + y * y);
+        double rotA = Math.Atan2(y, x) - (2.0 * Math.PI / 3.0);
+        x = rotR * Math.Cos(rotA);
+        y = rotR * Math.Sin(rotA);
+
+        if (rotateByHue)
+        {
+            double hr = Math.Sqrt(x * x + y * y);
+            double ha = Math.Atan2(y, x) - ((2.0 * Math.PI * hue) + (Math.PI / 2.0));
+            x = hr * Math.Cos(ha);
+            y = hr * Math.Sin(ha);
+        }
+
+        return ((float)(x + canvasRadius), (float)(y + canvasRadius));
+    }
+
+    // Pixel-space decode (analogous to ColorTriangleArea.WheelPointToColor's
+    // SV-extraction portion). Returns (s, v).
+    public static (double s, double v) DecodeSvPixel(
+        float px, float py, double hue, float canvasRadius, float svRadius, bool rotateByHue)
+    {
+        double x = (px - canvasRadius) / svRadius;
+        double y = (py - canvasRadius) / svRadius;
+
+        if (rotateByHue)
+        {
+            double r = Math.Sqrt(x * x + y * y);
+            double a = Math.Atan2(y, x) + ((2.0 * Math.PI * hue) + (Math.PI / 2.0));
+            x = r * Math.Cos(a);
+            y = r * Math.Sin(a);
+        }
+
+        double svX = x + TriangleSide;
+        double svY = -y + TriangleVerticalOffset;
+
+        const double x1 = TriangleSide;
+        const double y1 = TriangleHeight;
+        const double x2 = x1 * 2;
+        const double y2 = 0.0;
+
+        double vCurrent = ((svX * (y2 - y1)) - (svY * (x2 - x1)) + (x2 * y1) - (y2 * x1))
+                          / Math.Sqrt(Math.Pow(y2 - y1, 2) + Math.Pow(x2 - x1, 2));
+        double v = (y1 - vCurrent) / y1;
+        double sMax = x2 - (vCurrent / Math.Sin(Math.PI / 3.0));
+        double sCurrent = svY / Math.Sin(Math.PI / 3.0);
+        double s = sMax == 0 ? 0 : sCurrent / sMax;
+
+        return (Math.Clamp(s, 0, 1), Math.Clamp(v, 0, 1));
+    }
+}

--- a/ColorPicker.Core.Tests/RgbChannelSlidersTests.cs
+++ b/ColorPicker.Core.Tests/RgbChannelSlidersTests.cs
@@ -1,0 +1,96 @@
+namespace ColorPicker.Core.Tests;
+
+public class RgbChannelSlidersTests
+{
+    [Fact]
+    public void RedSlider_ReadsRedChannel()
+    {
+        var s = new RedSlider();
+        var hsl = ColorConversions.RgbToHsl(new RgbaColor(0.4, 0.6, 0.2, 0.9));
+        Assert.Equal(0.4f, s.ColorToPoint(hsl).X, 1e-4);
+    }
+
+    [Fact]
+    public void GreenSlider_ReadsGreenChannel()
+    {
+        var s = new GreenSlider();
+        var hsl = ColorConversions.RgbToHsl(new RgbaColor(0.4, 0.6, 0.2, 0.9));
+        Assert.Equal(0.6f, s.ColorToPoint(hsl).X, 1e-4);
+    }
+
+    [Fact]
+    public void BlueSlider_ReadsBlueChannel()
+    {
+        var s = new BlueSlider();
+        var hsl = ColorConversions.RgbToHsl(new RgbaColor(0.4, 0.6, 0.2, 0.9));
+        Assert.Equal(0.2f, s.ColorToPoint(hsl).X, 1e-4);
+    }
+
+    [Fact]
+    public void UpdateColor_ChangesOnlyTargetChannelInRgbSpace()
+    {
+        var s = new RedSlider();
+        var orig = ColorConversions.RgbToHsl(new RgbaColor(0.2, 0.6, 0.4, 0.5));
+        var after = s.UpdateColor(new UnitPoint(0.8f, 0.5f), orig);
+        var afterRgb = ColorConversions.HslToRgb(after);
+        Assert.Equal(0.8, afterRgb.R, 1e-4);
+        Assert.Equal(0.6, afterRgb.G, 1e-4);
+        Assert.Equal(0.4, afterRgb.B, 1e-4);
+        Assert.Equal(0.5, after.A, 1e-6);
+    }
+
+    [Fact]
+    public void UpdateColor_GrayscaleResult_PreservesCallerHue()
+    {
+        // Start from a grayscale color but with an explicit non-zero hue
+        // stored on the HslaColor (Core stores H independently of S/L).
+        // Sliding R to keep it grayscale should leave hue intact rather
+        // than snapping it to 0.
+        var s = new RedSlider();
+        var orig = new HslaColor(h: 0.42, s: 0, l: 0.5, a: 1.0);
+        var after = s.UpdateColor(new UnitPoint(0.5f, 0.5f), orig);
+        Assert.Equal(0.42, after.H, 1e-6);
+        var afterRgb = ColorConversions.HslToRgb(after);
+        Assert.Equal(0.5, afterRgb.R, 1e-4);
+        Assert.Equal(0.5, afterRgb.G, 1e-4);
+        Assert.Equal(0.5, afterRgb.B, 1e-4);
+    }
+
+    [Fact]
+    public void Vertical_UsesYAxis()
+    {
+        var s = new RedSlider(vertical: true);
+        var hsl = ColorConversions.RgbToHsl(new RgbaColor(0.4, 0.6, 0.2, 1.0));
+        var p = s.ColorToPoint(hsl);
+        Assert.Equal(0.5f,  p.X, 1e-5);
+        Assert.Equal(0.4f,  p.Y, 1e-4);
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(0.25)]
+    [InlineData(0.5)]
+    [InlineData(0.75)]
+    [InlineData(1.0)]
+    public void RoundTrip(double v)
+    {
+        foreach (var s in new RgbChannelSlider[] { new RedSlider(), new GreenSlider(), new BlueSlider() })
+        {
+            var rgb = new RgbaColor(0.3, 0.5, 0.7, 0.8);
+            var newRgb = s switch
+            {
+                RedSlider   => rgb.WithR(v),
+                GreenSlider => rgb.WithG(v),
+                BlueSlider  => rgb.WithB(v),
+                _ => throw new InvalidOperationException(),
+            };
+            var hsl = ColorConversions.RgbToHsl(newRgb);
+            var p = s.ColorToPoint(hsl);
+            var back = s.UpdateColor(p, hsl);
+            var backRgb = ColorConversions.HslToRgb(back);
+            Assert.Equal(newRgb.R, backRgb.R, 1e-4);
+            Assert.Equal(newRgb.G, backRgb.G, 1e-4);
+            Assert.Equal(newRgb.B, backRgb.B, 1e-4);
+        }
+    }
+}

--- a/ColorPicker.Core.Tests/SaturationValueTriangleTests.cs
+++ b/ColorPicker.Core.Tests/SaturationValueTriangleTests.cs
@@ -1,0 +1,103 @@
+namespace ColorPicker.Core.Tests;
+
+public class SaturationValueTriangleTests
+{
+    // Cross-validation: for many (s, v, hue, rotate) combinations the Core
+    // unit-square implementation must agree with the MAUI pixel-space
+    // reference within float precision.
+
+    public static IEnumerable<object[]> EncodeCases()
+    {
+        double[] svs = { 0.0, 0.1, 0.3, 0.5, 0.7, 0.9, 1.0 };
+        double[] hues = { 0.0, 0.13, 0.25, 0.5, 0.77, 0.99 };
+        foreach (var rot in new[] { true, false })
+        foreach (var h in hues)
+        foreach (var s in svs)
+        foreach (var v in svs)
+            yield return new object[] { s, v, h, rot };
+    }
+
+    [Theory]
+    [MemberData(nameof(EncodeCases))]
+    public void Encode_MatchesMauiPixelReference(double s, double v, double hue, bool rotate)
+    {
+        var tri = new SaturationValueTriangle(rotateByHue: rotate);
+        var hsv = new HsvaColor(hue, s, v, 1.0);
+        var hsl = ColorConversions.HsvToHsl(hsv);
+
+        var corePoint = tri.ColorToPoint(hsl);
+
+        // Reference: use a synthetic pixel canvas where SvRadius = canvasRadius,
+        // i.e. the triangle exactly fills the unit square (canvasRadius = 0.5).
+        var (refX, refY) = MauiTriangleReference.EncodeSvPixel(
+            s, v, hue, canvasRadius: 0.5f, svRadius: 0.5f, rotateByHue: rotate);
+
+        Assert.Equal(refX, corePoint.X, 5e-5);
+        Assert.Equal(refY, corePoint.Y, 5e-5);
+    }
+
+    [Theory]
+    [MemberData(nameof(EncodeCases))]
+    public void Decode_MatchesMauiPixelReference(double s, double v, double hue, bool rotate)
+    {
+        var tri = new SaturationValueTriangle(rotateByHue: rotate);
+
+        // Encode via reference to get a known-good pixel point, then decode
+        // both ways and compare.
+        var (px, py) = MauiTriangleReference.EncodeSvPixel(
+            s, v, hue, canvasRadius: 0.5f, svRadius: 0.5f, rotateByHue: rotate);
+
+        var hsv = new HsvaColor(hue, s, v, 1.0);
+        var hsl = ColorConversions.HsvToHsl(hsv);
+        var coreNew = tri.UpdateColor(new UnitPoint(px, py), hsl);
+        var coreHsv = ColorConversions.HslToHsv(coreNew);
+
+        var (refS, refV) = MauiTriangleReference.DecodeSvPixel(
+            px, py, hue, canvasRadius: 0.5f, svRadius: 0.5f, rotateByHue: rotate);
+
+        Assert.Equal(refS, coreHsv.S, 1e-4);
+        Assert.Equal(refV, coreHsv.V, 1e-4);
+        Assert.Equal(hue, coreHsv.H, 1e-6); // hue preserved
+    }
+
+    [Theory]
+    [InlineData(0.0,  1.0)]
+    [InlineData(0.5,  1.0)]
+    [InlineData(1.0,  1.0)]
+    [InlineData(0.25, 0.6)]
+    [InlineData(0.99, 0.99)]
+    public void RoundTrip_PreservesSV(double s, double v)
+    {
+        var tri = new SaturationValueTriangle(rotateByHue: true);
+        var orig = ColorConversions.HsvToHsl(new HsvaColor(0.3, s, v, 0.7));
+        var p = tri.ColorToPoint(orig);
+        var back = tri.UpdateColor(p, orig);
+        var backHsv = ColorConversions.HslToHsv(back);
+        Assert.Equal(s, backHsv.S, 1e-4);
+        Assert.Equal(v, backHsv.V, 1e-4);
+        Assert.Equal(0.3, backHsv.H, 1e-6);
+        Assert.Equal(orig.A, back.A);
+    }
+
+    [Fact]
+    public void IsInActiveArea_CenterIsActive()
+    {
+        var tri = new SaturationValueTriangle();
+        Assert.True(tri.IsInActiveArea(new UnitPoint(0.5f, 0.5f), default));
+    }
+
+    [Fact]
+    public void IsInActiveArea_CornerIsNotActive()
+    {
+        var tri = new SaturationValueTriangle();
+        Assert.False(tri.IsInActiveArea(new UnitPoint(0f, 0f), default));
+    }
+
+    [Fact]
+    public void FitToActiveArea_ProjectsExteriorOntoBoundingDisc()
+    {
+        var tri = new SaturationValueTriangle();
+        var f = tri.FitToActiveArea(new UnitPoint(0f, 0f), default);
+        Assert.Equal(0.5f, f.ToCentered().ToPolar().Radius, 1e-5);
+    }
+}

--- a/ColorPicker.Core/HueRing.cs
+++ b/ColorPicker.Core/HueRing.cs
@@ -1,0 +1,54 @@
+namespace ColorPicker.Core;
+
+/// <summary>
+/// Hue ring — the outer angular hue picker of ColorTriangle. Encodes hue
+/// purely angularly around a circle of radius 0.5 centered at (0.5, 0.5).
+///
+/// Encoding (matches MAUI <c>ColorTriangleArea</c> 1:1):
+/// <list type="bullet">
+///   <item>angle  = π − 2π · hue   (so hue 0 → angle π = left edge, same convention as HueSaturationDisc)</item>
+///   <item>radius = 0.5</item>
+/// </list>
+///
+/// Saturation, luminosity, and alpha pass through unchanged.
+/// </summary>
+public sealed class HueRing : IColorPickerArea
+{
+    /// <summary>Half-thickness (in unit-square units) used by hit testing.</summary>
+    public float HitTolerance { get; }
+
+    public HueRing(float hitTolerance = 0.05f)
+    {
+        if (hitTolerance < 0f) throw new ArgumentOutOfRangeException(nameof(hitTolerance));
+        HitTolerance = hitTolerance;
+    }
+
+    public bool IsInActiveArea(UnitPoint point, HslaColor color)
+    {
+        var r = point.ToCentered().ToPolar().Radius;
+        return Math.Abs(r - 0.5f) <= HitTolerance;
+    }
+
+    public UnitPoint FitToActiveArea(UnitPoint point, HslaColor color)
+    {
+        var polar = point.ToCentered().ToPolar();
+        if (polar.Radius == 0f)
+            return new PolarPoint(0.5f, 0f).ToCartesian().FromCentered();
+        return polar.WithRadius(0.5f).ToCartesian().FromCentered();
+    }
+
+    public HslaColor UpdateColor(UnitPoint point, HslaColor color)
+    {
+        var polar = point.ToCentered().ToPolar();
+        double h = (Math.PI - polar.Angle) / (2.0 * Math.PI);
+        h %= 1.0;
+        if (h < 0) h += 1.0;
+        return color.WithH(h);
+    }
+
+    public UnitPoint ColorToPoint(HslaColor color)
+    {
+        double angle = Math.PI - (2.0 * Math.PI * color.H);
+        return new PolarPoint(0.5f, (float)angle).ToCartesian().FromCentered();
+    }
+}

--- a/ColorPicker.Core/RgbChannelSliders.cs
+++ b/ColorPicker.Core/RgbChannelSliders.cs
@@ -1,0 +1,63 @@
+namespace ColorPicker.Core;
+
+/// <summary>
+/// Base class for RGB channel sliders (Red / Green / Blue). Each subclass
+/// plugs in a read/write pair for its specific channel; the geometry comes
+/// from <see cref="LinearTrack"/>.
+///
+/// <para>RGB sliders operate on the RGB projection of the caller's HSL
+/// color via <see cref="ColorConversions"/>. To match MAUI behavior, when
+/// the resulting RGB triple is grayscale (R=G=B) we keep the caller's
+/// original H and S so the picker indicator doesn't snap to hue 0.</para>
+/// </summary>
+public abstract class RgbChannelSlider : IColorPickerArea
+{
+    public LinearTrack Track { get; }
+
+    protected RgbChannelSlider(LinearTrack track) { Track = track; }
+
+    public bool IsInActiveArea(UnitPoint point, HslaColor color) => true;
+
+    public UnitPoint FitToActiveArea(UnitPoint point, HslaColor color)
+        => Track.PointFor(Track.ValueAt(point));
+
+    public HslaColor UpdateColor(UnitPoint point, HslaColor color)
+    {
+        var rgb = ColorConversions.HslToRgb(color);
+        var newRgb = Write(rgb, Track.ValueAt(point));
+        var newHsl = ColorConversions.RgbToHsl(newRgb);
+        // Preserve hue/saturation when the new color is grayscale (RgbToHsl
+        // returns H=S=0 by convention, but the caller's preferred hue should
+        // stick across grayscale transitions).
+        if (newHsl.S == 0)
+            newHsl = newHsl.WithH(color.H).WithS(color.S == 0 ? 0 : color.S);
+        return newHsl;
+    }
+
+    public UnitPoint ColorToPoint(HslaColor color)
+        => Track.PointFor(Read(ColorConversions.HslToRgb(color)));
+
+    protected abstract double Read(RgbaColor c);
+    protected abstract RgbaColor Write(RgbaColor c, double value);
+}
+
+public sealed class RedSlider : RgbChannelSlider
+{
+    public RedSlider(bool vertical = false) : base(new LinearTrack(vertical)) { }
+    protected override double Read(RgbaColor c) => c.R;
+    protected override RgbaColor Write(RgbaColor c, double v) => c.WithR(v);
+}
+
+public sealed class GreenSlider : RgbChannelSlider
+{
+    public GreenSlider(bool vertical = false) : base(new LinearTrack(vertical)) { }
+    protected override double Read(RgbaColor c) => c.G;
+    protected override RgbaColor Write(RgbaColor c, double v) => c.WithG(v);
+}
+
+public sealed class BlueSlider : RgbChannelSlider
+{
+    public BlueSlider(bool vertical = false) : base(new LinearTrack(vertical)) { }
+    protected override double Read(RgbaColor c) => c.B;
+    protected override RgbaColor Write(RgbaColor c, double v) => c.WithB(v);
+}

--- a/ColorPicker.Core/RgbaColor.cs
+++ b/ColorPicker.Core/RgbaColor.cs
@@ -21,6 +21,11 @@ public readonly struct RgbaColor : IEquatable<RgbaColor>
     public HslaColor ToHsla() => ColorConversions.RgbToHsl(this);
     public HsvaColor ToHsva() => ColorConversions.RgbToHsv(this);
 
+    public RgbaColor WithR(double r) => new(r, G, B, A);
+    public RgbaColor WithG(double g) => new(R, g, B, A);
+    public RgbaColor WithB(double b) => new(R, G, b, A);
+    public RgbaColor WithA(double a) => new(R, G, B, a);
+
     public bool Equals(RgbaColor other) => R == other.R && G == other.G && B == other.B && A == other.A;
     public override bool Equals(object? obj) => obj is RgbaColor other && Equals(other);
     public override int GetHashCode() => HashCode.Combine(R, G, B, A);

--- a/ColorPicker.Core/SaturationValueTriangle.cs
+++ b/ColorPicker.Core/SaturationValueTriangle.cs
@@ -1,0 +1,125 @@
+namespace ColorPicker.Core;
+
+/// <summary>
+/// HSV saturation/value triangle — the inner picker of ColorTriangle.
+/// Operates on the unit square; the reference triangle is the equilateral
+/// triangle inscribed in a circle of radius 0.5 centered at (0.5, 0.5),
+/// apex up.
+///
+/// The mapping between (S, V) and triangle position is the same one used
+/// by the existing MAUI <c>ColorTriangleArea</c>, ported 1:1 from pixel
+/// space to unit-square coordinates (SvRadius is replaced by 0.5
+/// throughout). The barycentric formulas are kept verbatim.
+///
+/// H is preserved from the input color (Core stores H explicitly so the
+/// MAUI <c>_lastHue</c> mechanism is unnecessary). A is also preserved.
+///
+/// <para>If <see cref="RotateByHue"/> is true the triangle is rotated by
+/// the current hue, matching MAUI's <c>RotateTriangleByHue</c> mode.</para>
+/// </summary>
+public sealed class SaturationValueTriangle : IColorPickerArea
+{
+    public bool RotateByHue { get; }
+
+    public SaturationValueTriangle(bool rotateByHue = true) { RotateByHue = rotateByHue; }
+
+    // Reference triangle constants (MAUI ColorTriangleArea, lines 420-422).
+    // Tiny epsilon offsets are preserved verbatim — they keep the barycentric
+    // formula from going degenerate at the triangle boundary.
+    const float TriangleHeight = 1.5000001F;
+    const float TriangleSide = 0.8660244F;
+    const float TriangleVerticalOffset = 0.5000001F;
+
+    // Active area = the bounding disc of radius 0.5. This matches MAUI's
+    // LimitToSvTriangle which actually clamps to the disc, not the triangle
+    // itself (the visual triangle clip is render-only).
+    public bool IsInActiveArea(UnitPoint point, HslaColor color)
+        => point.ToCentered().ToPolar().Radius <= 0.5f;
+
+    public UnitPoint FitToActiveArea(UnitPoint point, HslaColor color)
+    {
+        var polar = point.ToCentered().ToPolar();
+        if (polar.Radius > 0.5f) polar = polar.WithRadius(0.5f);
+        return polar.ToCartesian().FromCentered();
+    }
+
+    public HslaColor UpdateColor(UnitPoint point, HslaColor color)
+    {
+        var hsv = ColorConversions.HslToHsv(color);
+        var (s, v) = DecodeSv(point, hsv.H);
+        // Keep the caller's hue explicitly (don't round-trip through RGB);
+        // this preserves hue across grayscale transitions for free.
+        var newHsv = new HsvaColor(hsv.H, s, v, hsv.A);
+        return ColorConversions.HsvToHsl(newHsv);
+    }
+
+    public UnitPoint ColorToPoint(HslaColor color)
+    {
+        var hsv = ColorConversions.HslToHsv(color);
+        return EncodeSv(hsv.S, hsv.V, hsv.H);
+    }
+
+    UnitPoint EncodeSv(double s, double v, double hue)
+    {
+        // Mirror of MAUI ColorTriangleArea.UpdateLocations (lines 211-236),
+        // with the pixel SvRadius replaced by 0.5.
+        double lumX = TriangleSide * (1 - 2 * s);
+        double lumY = TriangleHeight;
+
+        var polar = new UnitPoint((float)lumX, (float)lumY).ToPolar();
+        polar = polar.WithRadius((float)(polar.Radius * v));
+
+        var local = polar.ToCartesian();
+        local = new UnitPoint(-local.X, local.Y - 1f);
+        local = new UnitPoint(local.X * 0.5f, local.Y * 0.5f);
+
+        // Rotate -2π/3 (constant triangle orientation correction).
+        local = local.ToPolar().AddAngle((float)(-2.0 * Math.PI / 3.0)).ToCartesian();
+
+        if (RotateByHue)
+        {
+            local = local.ToPolar()
+                .AddAngle((float)(-((2.0 * Math.PI * hue) + (Math.PI / 2.0))))
+                .ToCartesian();
+        }
+
+        return local.FromCentered();
+    }
+
+    (double s, double v) DecodeSv(UnitPoint point, double hue)
+    {
+        // Convert to the unit-radius local frame (MAUI's ToSvCoordinates,
+        // with SvRadius = 0.5 → multiply by 2).
+        var local = point.ToCentered();
+        local = new UnitPoint(local.X * 2f, local.Y * 2f);
+
+        if (RotateByHue)
+        {
+            local = local.ToPolar()
+                .AddAngle((float)((2.0 * Math.PI * hue) + (Math.PI / 2.0)))
+                .ToCartesian();
+        }
+
+        // Barycentric math — verbatim from MAUI WheelPointToColor (lines 435-448).
+        float svX = local.X + TriangleSide;
+        float svY = -local.Y + TriangleVerticalOffset;
+
+        const float x1 = TriangleSide;
+        const float y1 = TriangleHeight;
+        const float x2 = x1 * 2;
+        const float y2 = 0F;
+
+        double vCurrent = ((svX * (y2 - y1)) - (svY * (x2 - x1)) + (x2 * y1) - (y2 * x1))
+                          / Math.Sqrt(Math.Pow(y2 - y1, 2) + Math.Pow(x2 - x1, 2));
+        double v = (y1 - vCurrent) / y1;
+        double sMax = x2 - (vCurrent / Math.Sin(Math.PI / 3.0));
+        double sCurrent = svY / Math.Sin(Math.PI / 3.0);
+        double s = sMax == 0 ? 0 : sCurrent / sMax;
+
+        if (s < 0) s = 0;
+        if (s > 1) s = 1;
+        if (v < 0) v = 0;
+        if (v > 1) v = 1;
+        return (s, v);
+    }
+}


### PR DESCRIPTION
Completes the math-only portion of the ColorPicker.Core split.

### Added
- `SaturationValueTriangle` — 1:1 port of the MAUI `ColorTriangleArea` barycentric SV math, on the unit square. Cross-validated against a pixel-space reference implementation (`MauiTriangleReference`) over 1176 (S, V, hue, rotate) combinations; encode + decode agree within 1e-4.
- `HueRing` — outer angular hue picker (sibling of `LuminosityRing`).
- `RedSlider` / `GreenSlider` / `BlueSlider` (`RgbChannelSlider` base) — routed through `ColorConversions`. Preserves caller hue/saturation when the result is grayscale, matching MAUI behavior.

### Notes on `_lastHue`

MAUI's `ColorTriangleArea` keeps a mutable `_lastHue` field because `Color` only stores RGB and derives hue on demand (so hue is lost across grayscale). `HslaColor` in Core stores H explicitly, so this mechanism is unnecessary in Core — the caller's H survives any grayscale round-trip naturally.

### Tests
1335 / 1335 passing in `ColorPicker.Core.Tests` (~90 ms). +1206 from this PR (most are parameterized cross-validation triangle cases).

### Out of scope
- Wiring Core back into the MAUI controls (needs packaging decision)
- Phase 5 dynamic indicator radius
- `picker-graph-cycle-safe` (separate todo)