### PR TITLE
Wire ColorPicker.Core math into MAUI controls

### DIFF
--- a/ColorPicker.Core/HslChannelSliders.cs
+++ b/ColorPicker.Core/HslChannelSliders.cs
@@ -25,34 +25,37 @@ public abstract class HslChannelSlider : IColorPickerArea
 
     public UnitPoint ColorToPoint(HslaColor color) => Track.PointFor(Read(color));
 
-    protected abstract double Read(HslaColor color);
-    protected abstract HslaColor Write(HslaColor color, double value);
+    /// <summary>Read this slider's channel from <paramref name="color"/>.</summary>
+    public abstract double Read(HslaColor color);
+
+    /// <summary>Return a copy of <paramref name="color"/> with this slider's channel set to <paramref name="value"/>.</summary>
+    public abstract HslaColor Write(HslaColor color, double value);
 }
 
 public sealed class HueSlider : HslChannelSlider
 {
     public HueSlider(bool vertical = false) : base(new LinearTrack(vertical)) { }
-    protected override double Read(HslaColor c) => c.H;
-    protected override HslaColor Write(HslaColor c, double v) => c.WithH(v);
+    public override double Read(HslaColor c) => c.H;
+    public override HslaColor Write(HslaColor c, double v) => c.WithH(v);
 }
 
 public sealed class SaturationSlider : HslChannelSlider
 {
     public SaturationSlider(bool vertical = false) : base(new LinearTrack(vertical)) { }
-    protected override double Read(HslaColor c) => c.S;
-    protected override HslaColor Write(HslaColor c, double v) => c.WithS(v);
+    public override double Read(HslaColor c) => c.S;
+    public override HslaColor Write(HslaColor c, double v) => c.WithS(v);
 }
 
 public sealed class LuminositySlider : HslChannelSlider
 {
     public LuminositySlider(bool vertical = false) : base(new LinearTrack(vertical)) { }
-    protected override double Read(HslaColor c) => c.L;
-    protected override HslaColor Write(HslaColor c, double v) => c.WithL(v);
+    public override double Read(HslaColor c) => c.L;
+    public override HslaColor Write(HslaColor c, double v) => c.WithL(v);
 }
 
 public sealed class AlphaSlider : HslChannelSlider
 {
     public AlphaSlider(bool vertical = false) : base(new LinearTrack(vertical)) { }
-    protected override double Read(HslaColor c) => c.A;
-    protected override HslaColor Write(HslaColor c, double v) => c.WithA(v);
+    public override double Read(HslaColor c) => c.A;
+    public override HslaColor Write(HslaColor c, double v) => c.WithA(v);
 }

--- a/ColorPicker.Core/RgbChannelSliders.cs
+++ b/ColorPicker.Core/RgbChannelSliders.cs
@@ -37,27 +37,30 @@ public abstract class RgbChannelSlider : IColorPickerArea
     public UnitPoint ColorToPoint(HslaColor color)
         => Track.PointFor(Read(ColorConversions.HslToRgb(color)));
 
-    protected abstract double Read(RgbaColor c);
-    protected abstract RgbaColor Write(RgbaColor c, double value);
+    /// <summary>Read this slider's channel from <paramref name="c"/>.</summary>
+    public abstract double Read(RgbaColor c);
+
+    /// <summary>Return a copy of <paramref name="c"/> with this slider's channel set to <paramref name="value"/>.</summary>
+    public abstract RgbaColor Write(RgbaColor c, double value);
 }
 
 public sealed class RedSlider : RgbChannelSlider
 {
     public RedSlider(bool vertical = false) : base(new LinearTrack(vertical)) { }
-    protected override double Read(RgbaColor c) => c.R;
-    protected override RgbaColor Write(RgbaColor c, double v) => c.WithR(v);
+    public override double Read(RgbaColor c) => c.R;
+    public override RgbaColor Write(RgbaColor c, double v) => c.WithR(v);
 }
 
 public sealed class GreenSlider : RgbChannelSlider
 {
     public GreenSlider(bool vertical = false) : base(new LinearTrack(vertical)) { }
-    protected override double Read(RgbaColor c) => c.G;
-    protected override RgbaColor Write(RgbaColor c, double v) => c.WithG(v);
+    public override double Read(RgbaColor c) => c.G;
+    public override RgbaColor Write(RgbaColor c, double v) => c.WithG(v);
 }
 
 public sealed class BlueSlider : RgbChannelSlider
 {
     public BlueSlider(bool vertical = false) : base(new LinearTrack(vertical)) { }
-    protected override double Read(RgbaColor c) => c.B;
-    protected override RgbaColor Write(RgbaColor c, double v) => c.WithB(v);
+    public override double Read(RgbaColor c) => c.B;
+    public override RgbaColor Write(RgbaColor c, double v) => c.WithB(v);
 }

--- a/ColorPicker/ColorPicker.csproj
+++ b/ColorPicker/ColorPicker.csproj
@@ -7,6 +7,7 @@
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>annotations</Nullable>
 		<CheckEolTargetFramework>false</CheckEolTargetFramework>
 
 		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net8.0-ios'">14.2</SupportedOSPlatformVersion>
@@ -53,6 +54,18 @@
 
 	<ItemGroup>
 	  <None Include="..\README.md" Pack="true" PackagePath="\" />
+	</ItemGroup>
+
+	<!--
+	  Embed the platform-agnostic ColorPicker.Core math sources directly so the
+	  MAUI package ships as a single nupkg with no extra runtime dependency.
+	  Core remains an independently-buildable project for cross-platform unit
+	  tests; promoting it to a separate NuGet later is a one-line swap.
+	-->
+	<ItemGroup>
+	  <Compile Include="..\ColorPicker.Core\**\*.cs"
+	           Exclude="..\ColorPicker.Core\bin\**;..\ColorPicker.Core\obj\**"
+	           LinkBase="Core" />
 	</ItemGroup>
 
 	<PropertyGroup Label="MinVer">

--- a/ColorPicker/Controls/AlphaSliderFactory.cs
+++ b/ColorPicker/Controls/AlphaSliderFactory.cs
@@ -1,11 +1,16 @@
+using ColorPicker.Core;
+
 namespace ColorPicker.Controls;
 
 public static class AlphaSliderFactory
 {
-    public static float NewValueAlpha(Color color) => (float)color.Alpha;
+    static readonly Core.AlphaSlider _alpha = new();
+
+    public static float NewValueAlpha(Color color) => (float)_alpha.Read(color.ToHsla());
 
     public static Color GetNewColorAlpha(float newValue, Color oldColor)
-        => Color.FromRgba(oldColor.Red, oldColor.Green, oldColor.Blue, newValue);
+        => Color.FromRgba(oldColor.Red, oldColor.Green, oldColor.Blue,
+                          _alpha.Write(oldColor.ToHsla(), newValue).A);
 
     public static SKPaint GetPaintAlpha(Color color, SKPoint startPoint, SKPoint endPoint)
     {

--- a/ColorPicker/Controls/ColorDisc.cs
+++ b/ColorPicker/Controls/ColorDisc.cs
@@ -1,7 +1,12 @@
+using ColorPicker.Core;
+
 namespace ColorPicker.Controls;
 
 public class ColorDisc : SkiaPickerBase
 {
+    static readonly HueSaturationDisc _hsDisc = new();
+    static readonly Core.LuminosityRing _lRing = new();
+
     long?   _locationHsProgressId    = null;
     long?   _locationLProgressId     = null;
 
@@ -162,52 +167,44 @@ public class ColorDisc : SkiaPickerBase
 
     void UpdateLocations(Color color, float canvasRadius)
     {
+        var hsl = color.ToHsla();
+
         if (color.GetLuminosity() != 0 || !IsInHsArea(_locationHs, canvasRadius))
         {
-            var angleHs  = (0.5 - color.GetHue()) * (2 * Math.PI);
-            var radiusHs = HsRadius(canvasRadius) * color.GetSaturation();
-
-            var resultHs = FromPolar(new PolarPoint((float)radiusHs, (float)angleHs));
-            resultHs.X += canvasRadius;
-            resultHs.Y += canvasRadius;
-            _locationHs = resultHs;
+            var hsUnit = _hsDisc.ColorToPoint(hsl);
+            _locationHs = FromUnit(hsUnit, canvasRadius, HsRadius(canvasRadius));
         }
 
-        var polarL      = ToPolar(ToLCoordinates(_locationL, canvasRadius));
-        polarL.Angle -= (float)Math.PI / 2F;
-        var signOld     = polarL.Angle <= 0 ? 1 : -1;
-        var angleL      = color.GetLuminosity() * Math.PI * signOld;
-
-        var resultL     = FromPolar(new PolarPoint(LRadius(canvasRadius), (float)(angleL - (Math.PI / 2))));
-        resultL.X += canvasRadius;
-        resultL.Y += canvasRadius;
-        _locationL = resultL;
+        var prevLUnit = ToUnit(_locationL, canvasRadius, LRadius(canvasRadius));
+        var lUnit     = _lRing.ColorToPoint(hsl, prevLUnit);
+        _locationL    = FromUnit(lUnit, canvasRadius, LRadius(canvasRadius));
     }
 
     void UpdateColors(float canvasRadius)
     {
-        var hsPoint    = ToHsCoordinates(_locationHs, canvasRadius);
-        var lPoint     = ToLCoordinates(_locationL, canvasRadius);
+        var hsl = SelectedColor.ToHsla();
+        var hsUnit = ToUnit(_locationHs, canvasRadius, HsRadius(canvasRadius));
+        var lUnit  = ToUnit(_locationL,  canvasRadius, LRadius(canvasRadius));
 
-        var newColor        = WheelPointToColor(hsPoint, lPoint);
-        SelectedColor = newColor;
+        hsl = _hsDisc.UpdateColor(hsUnit, hsl);
+        hsl = _lRing .UpdateColor(lUnit,  hsl);
+
+        SelectedColor = hsl.ToMauiColor();
     }
 
     bool IsInHsArea(SKPoint point, float canvasRadius)
-    {
-        var polar = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
-        return polar.Radius <= HsRadius(canvasRadius);
-    }
+        => _hsDisc.IsInActiveArea(ToUnit(point, canvasRadius, HsRadius(canvasRadius)), default);
 
     bool IsInLArea(SKPoint point, float canvasRadius)
     {
         if (!ShowLuminosityRing)
             return false;
 
-        var polar = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
-
-        return polar.Radius <= LRadius(canvasRadius) + (GetIndicatorRadiusPixels() / 2F)
-            && polar.Radius >= LRadius(canvasRadius) - (GetIndicatorRadiusPixels() / 2F);
+        // Hit tolerance lives in pixel space (half the indicator radius); convert
+        // to unit-square units by scaling against the L-ring radius.
+        var tolUnits = (GetIndicatorRadiusPixels() / 2F) / (2F * LRadius(canvasRadius));
+        var ring = new Core.LuminosityRing(tolUnits);
+        return ring.IsInActiveArea(ToUnit(point, canvasRadius, LRadius(canvasRadius)), default);
     }
 
     void PaintBackground(SKCanvas canvas, float canvasRadius)
@@ -284,84 +281,28 @@ public class ColorDisc : SkiaPickerBase
         canvas.DrawPaint(paint);
     }
 
-    SKPoint ToHsCoordinates(SKPoint point, float canvasRadius)
-    {
-        var result = new SKPoint(point.X, point.Y);
-
-        result.X -= canvasRadius;
-        result.Y -= canvasRadius;
-        result.X /= HsRadius(canvasRadius);
-        result.Y /= HsRadius(canvasRadius);
-
-        return result;
-    }
-
-    SKPoint ToLCoordinates(SKPoint point, float canvasRadius)
-    {
-        var result = new SKPoint(point.X, point.Y);
-
-        result.X -= canvasRadius;
-        result.Y -= canvasRadius;
-        result.X /= LRadius(canvasRadius);
-        result.Y /= LRadius(canvasRadius);
-
-        return result;
-    }
-
-    Color WheelPointToColor(SKPoint pointHS, SKPoint pointL)
-    {
-        var polarHS     = ToPolar(pointHS);
-        var polarL      = ToPolar(pointL);
-
-        polarL.Angle += (float)Math.PI / 2F;
-        polarL = ToPolar(FromPolar(polarL));
-
-        var h   = (Math.PI - polarHS.Angle) / (2 * Math.PI);
-        var s   = polarHS.Radius;
-        var l   = Math.Abs(polarL.Angle) / Math.PI;
-
-        return Color.FromHsla(h, s, l, SelectedColor.Alpha);
-    }
-
     SKPoint LimitToHsRadius(SKPoint point, float canvasRadius)
     {
-        var polar       = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
-        polar.Radius = polar.Radius < HsRadius(canvasRadius) ? polar.Radius : HsRadius(canvasRadius);
-        var result      = FromPolar(polar);
-
-        result.X += canvasRadius;
-        result.Y += canvasRadius;
-
-        return result;
+        var unit = ToUnit(point, canvasRadius, HsRadius(canvasRadius));
+        var fit  = _hsDisc.FitToActiveArea(unit, default);
+        return FromUnit(fit, canvasRadius, HsRadius(canvasRadius));
     }
 
     SKPoint LimitToLRadius(SKPoint point, float canvasRadius)
     {
-        var polar       = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
-        polar.Radius = LRadius(canvasRadius);
-        var result      = FromPolar(polar);
-
-        result.X += canvasRadius;
-        result.Y += canvasRadius;
-
-        return result;
+        var unit = ToUnit(point, canvasRadius, LRadius(canvasRadius));
+        var fit  = _lRing.FitToActiveArea(unit, default);
+        return FromUnit(fit, canvasRadius, LRadius(canvasRadius));
     }
 
-    static PolarPoint ToPolar(SKPoint point)
-    {
-        var radius    = (float)Math.Sqrt((point.X * point.X) + (point.Y * point.Y));
-        var angle     = (float)Math.Atan2(point.Y, point.X);
+    // Pixel ↔ unit-square coordinate bridge (per active-area radius).
+    static UnitPoint ToUnit(SKPoint pixel, float canvasRadius, float activeRadius)
+        => new((float)((pixel.X - canvasRadius) / (2.0 * activeRadius) + 0.5),
+               (float)((pixel.Y - canvasRadius) / (2.0 * activeRadius) + 0.5));
 
-        return new PolarPoint(radius, angle);
-    }
-
-    static SKPoint FromPolar(PolarPoint point)
-    {
-        var x     = (float)(point.Radius * Math.Cos(point.Angle));
-        var y     = (float)(point.Radius * Math.Sin(point.Angle));
-
-        return new SKPoint(x, y);
-    }
+    static SKPoint FromUnit(UnitPoint unit, float canvasRadius, float activeRadius)
+        => new((float)((unit.X - 0.5) * 2.0 * activeRadius + canvasRadius),
+               (float)((unit.Y - 0.5) * 2.0 * activeRadius + canvasRadius));
 
     // Small margin so the picker indicator (outer stroke + antialiasing)
     // does not get clipped at the canvas edge.

--- a/ColorPicker/Controls/ColorTriangleArea.cs
+++ b/ColorPicker/Controls/ColorTriangleArea.cs
@@ -1,7 +1,14 @@
+using ColorPicker.Core;
+using PolarPoint = ColorPicker.Classes.PolarPoint;
+
 namespace ColorPicker.Controls;
 
 public class ColorTriangleArea : SkiaPickerBase
 {
+    static readonly SaturationValueTriangle _triangleRotated = new(rotateByHue: true);
+    static readonly SaturationValueTriangle _triangleFixed   = new(rotateByHue: false);
+    static readonly HueRing                 _hueRing         = new();
+
     double _lastHue = 0;
     bool _zeroSL = false;
     long? _locationSvProgressId = null;
@@ -206,74 +213,65 @@ public class ColorTriangleArea : SkiaPickerBase
         return ((canvas.Width - size) / 2F, (canvas.Height - size) / 2F);
     }
 
+    SaturationValueTriangle Triangle => RotateTriangleByHue ? _triangleRotated : _triangleFixed;
+
     void UpdateLocations(Color color, float canvasRadius)
     {
-        ColorToHsv(color, out _, out var saturation, out var value);
+        // Use _lastHue (not color.GetHue()) so the SV indicator stays put when
+        // the selected color is grayscale — matches the existing MAUI behavior.
+        var hsla = new HslaColor(_lastHue,
+                                 color.GetSaturation(),
+                                 color.GetLuminosity(),
+                                 color.Alpha);
 
-        var luminosityX = -(float)((2 * _triangleSide * saturation) - _triangleSide);
-        var luminosityY = _triangleHeight;
-
-        var polarValue = ToPolar(new SKPoint(luminosityX, luminosityY));
-        polarValue.Radius *= (float)value;
-
-        _locationSv = FromPolar(polarValue);
-        _locationSv.X = -_locationSv.X;
-        _locationSv.Y -= 1;
-        _locationSv.X *= SvRadius(canvasRadius);
-        _locationSv.Y *= SvRadius(canvasRadius);
-
-        polarValue = ToPolar(new SKPoint(_locationSv.X, _locationSv.Y));
-        polarValue.Angle -= (float)(2 * Math.PI / 3);
-        _locationSv = FromPolar(polarValue);
-
-        _locationSv.X += canvasRadius;
-        _locationSv.Y += canvasRadius;
-
-        if (RotateTriangleByHue)
-        {
-            var rotationHue = SKMatrix.CreateRotation(-(float)((2D * Math.PI * _lastHue) + (Math.PI / 2D)), canvasRadius, canvasRadius);
-            _locationSv = rotationHue.MapPoint(_locationSv);
-        }
+        var svUnit = Triangle.ColorToPoint(hsla);
+        _locationSv = FromUnit(svUnit, canvasRadius, SvRadius(canvasRadius));
 
         var angleH = _lastHue * Math.PI * 2;
+        _locationMiddleH = FromPolar(new PolarPoint(HRadius(canvasRadius),                                  (float)(Math.PI - angleH)));
+        _locationMiddleH = OffsetByCenter(_locationMiddleH, canvasRadius);
 
-        _locationMiddleH = FromPolar(new PolarPoint(HRadius(canvasRadius), (float)(Math.PI - angleH)));
-        _locationMiddleH.X += canvasRadius;
-        _locationMiddleH.Y += canvasRadius;
+        _locationH1 = FromPolar(new PolarPoint(HRadius(canvasRadius) + GetIndicatorRadiusPixels(),          (float)(Math.PI - angleH)));
+        _locationH1 = OffsetByCenter(_locationH1, canvasRadius);
 
-        _locationH1 = FromPolar(new PolarPoint(HRadius(canvasRadius) + GetIndicatorRadiusPixels(), (float)(Math.PI - angleH)));
-        _locationH1.X += canvasRadius;
-        _locationH1.Y += canvasRadius;
-
-        _locationH2 = FromPolar(new PolarPoint(HRadius(canvasRadius) - GetIndicatorRadiusPixels(), (float)(Math.PI - angleH)));
-        _locationH2.X += canvasRadius;
-        _locationH2.Y += canvasRadius;
+        _locationH2 = FromPolar(new PolarPoint(HRadius(canvasRadius) - GetIndicatorRadiusPixels(),          (float)(Math.PI - angleH)));
+        _locationH2 = OffsetByCenter(_locationH2, canvasRadius);
     }
 
     void UpdateColors(float canvasRadius)
     {
-        var svPoint = ToSvCoordinates(_locationSv, canvasRadius);
-        var hPoint = ToHCoordinates(_locationH1, canvasRadius);
-        var newColor = WheelPointToColor(svPoint, hPoint);
+        var hsla = new HslaColor(_lastHue,
+                                 SelectedColor.GetSaturation(),
+                                 SelectedColor.GetLuminosity(),
+                                 SelectedColor.Alpha);
+
+        var svUnit = ToUnit(_locationSv, canvasRadius, SvRadius(canvasRadius));
+        // Decode SV with the OLD hue (_lastHue, baked into hsla.H) — same
+        // ordering MAUI uses: triangle decode then hue assignment.
+        hsla = Triangle.UpdateColor(svUnit, hsla);
+
+        var hUnit = ToUnit(_locationH1, canvasRadius, HRadius(canvasRadius));
+        hsla = _hueRing.UpdateColor(hUnit, hsla);
+
+        var newColor = hsla.ToMauiColor();
 
         if (_zeroSL && (newColor.GetSaturation() > 0))
         {
             newColor = Color.FromHsla(_lastHue, newColor.GetSaturation(), newColor.GetLuminosity(), newColor.Alpha);
         }
 
+        _lastHue = hsla.H;
         SelectedColor = newColor;
     }
 
     bool IsInSvArea(SKPoint point, float canvasRadius)
-    {
-        var polar = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
-        return polar.Radius <= SvRadius(canvasRadius);
-    }
+        => Triangle.IsInActiveArea(ToUnit(point, canvasRadius, SvRadius(canvasRadius)), default);
 
     bool IsInHArea(SKPoint point, float canvasRadius)
     {
-        var polar = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
-        return polar.Radius <= HRadius(canvasRadius) + GetIndicatorRadiusPixels() && polar.Radius >= HRadius(canvasRadius) - GetIndicatorRadiusPixels();
+        // MAUI tolerance: ±indicatorPx in pixel space.
+        var tolUnits = GetIndicatorRadiusPixels() / (2F * HRadius(canvasRadius));
+        return new HueRing(tolUnits).IsInActiveArea(ToUnit(point, canvasRadius, HRadius(canvasRadius)), default);
     }
 
     void PaintBackground(SKCanvas canvas, float canvasRadius)
@@ -393,93 +391,41 @@ public class ColorTriangleArea : SkiaPickerBase
         canvas.DrawCircle(center, SvRadius(canvasRadius), paint);
     }
 
-    SKPoint ToSvCoordinates(SKPoint point, float canvasRadius)
-    {
-        var result = new SKPoint(point.X, point.Y);
-
-        result.X -= canvasRadius;
-        result.Y -= canvasRadius;
-        result.X /= SvRadius(canvasRadius);
-        result.Y /= SvRadius(canvasRadius);
-
-        return result;
-    }
-
-    SKPoint ToHCoordinates(SKPoint point, float canvasRadius)
-    {
-        var result = new SKPoint(point.X, point.Y);
-
-        result.X -= canvasRadius;
-        result.Y -= canvasRadius;
-        result.X /= HRadius(canvasRadius);
-        result.Y /= HRadius(canvasRadius);
-
-        return result;
-    }
-
-    const float _triangleHeight = 1.5000001F;
-    const float _triangleSide = 0.8660244F;
-    const float _triangleVerticalOffset = 0.5000001F;
-
-    Color WheelPointToColor(SKPoint pointSV, SKPoint pointH)
-    {
-        if (RotateTriangleByHue)
-        {
-            var rotationHue = SKMatrix.CreateRotation((float)((2D * Math.PI * _lastHue) + (Math.PI / 2D)));
-            pointSV = rotationHue.MapPoint(pointSV);
-        }
-
-        var polarH = ToPolar(pointH);
-        var h = (-polarH.Angle + Math.PI) / (2 * Math.PI);
-
-        pointSV.Y = -pointSV.Y + _triangleVerticalOffset;
-        pointSV.X += _triangleSide;
-
-        var x1 = _triangleSide;
-        var y1 = _triangleHeight;
-        var x2 = x1 * 2;
-        var y2 = 0F;
-
-        var vCurrent = ((pointSV.X * (y2 - y1)) - (pointSV.Y * (x2 - x1)) + (x2 * y1) - (y2 * x1)) / Math.Sqrt(Math.Pow(y2 - y1, 2) + Math.Pow(x2 - x1, 2));
-        var v = (y1 - vCurrent) / y1;
-
-        var sMax = x2 - (vCurrent / Math.Sin(Math.PI / 3));
-        var sCurrent = pointSV.Y / Math.Sin(Math.PI / 3);
-        var s = sCurrent / sMax;
-
-        _lastHue = h;
-        var result = ColorFromHsv(h, s, v, SelectedColor.Alpha);
-
-        return result;
-    }
-
     SKPoint LimitToSvTriangle(SKPoint point, float canvasRadius)
     {
-        var polar = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
-        polar.Radius = polar.Radius < SvRadius(canvasRadius) ? polar.Radius : SvRadius(canvasRadius);
-
-        var result = FromPolar(polar);
-        result.X += canvasRadius;
-        result.Y += canvasRadius;
-        return result;
+        var unit = ToUnit(point, canvasRadius, SvRadius(canvasRadius));
+        var fit  = Triangle.FitToActiveArea(unit, default);
+        return FromUnit(fit, canvasRadius, SvRadius(canvasRadius));
     }
+
+    // Triangle constants — used by the SV-triangle rendering path (vertices,
+    // gradient stretch). The encoding/decoding math has moved to
+    // ColorPicker.Core.SaturationValueTriangle which carries its own copies.
+    const float _triangleHeight         = 1.5000001F;
+    const float _triangleSide           = 0.8660244F;
+    const float _triangleVerticalOffset = 0.5000001F;
 
     void LimitToHRadius(SKPoint point, float canvasRadius)
     {
-        var point1 = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
-        point1.Radius = HRadius(canvasRadius) + GetIndicatorRadiusPixels();
+        var polar = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
+        var pOuter = new PolarPoint(HRadius(canvasRadius) + GetIndicatorRadiusPixels(), polar.Angle);
+        var pInner = new PolarPoint(HRadius(canvasRadius) - GetIndicatorRadiusPixels(), polar.Angle);
 
-        var point2 = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
-        point1.Radius = HRadius(canvasRadius) - GetIndicatorRadiusPixels();
-
-        _locationH1 = FromPolar(point1);
-        _locationH2 = FromPolar(point2);
-
-        _locationH1.X += canvasRadius;
-        _locationH1.Y += canvasRadius;
-        _locationH2.X += canvasRadius;
-        _locationH2.Y += canvasRadius;
+        _locationH1 = OffsetByCenter(FromPolar(pOuter), canvasRadius);
+        _locationH2 = OffsetByCenter(FromPolar(pInner), canvasRadius);
     }
+
+    static SKPoint OffsetByCenter(SKPoint p, float canvasRadius)
+        => new(p.X + canvasRadius, p.Y + canvasRadius);
+
+    // Pixel ↔ unit-square coordinate bridge (per active-area radius).
+    static UnitPoint ToUnit(SKPoint pixel, float canvasRadius, float activeRadius)
+        => new((float)((pixel.X - canvasRadius) / (2.0 * activeRadius) + 0.5),
+               (float)((pixel.Y - canvasRadius) / (2.0 * activeRadius) + 0.5));
+
+    static SKPoint FromUnit(UnitPoint unit, float canvasRadius, float activeRadius)
+        => new((float)((unit.X - 0.5) * 2.0 * activeRadius + canvasRadius),
+               (float)((unit.Y - 0.5) * 2.0 * activeRadius + canvasRadius));
 
     static PolarPoint ToPolar(SKPoint point)
     {

--- a/ColorPicker/Controls/CoreInterop.cs
+++ b/ColorPicker/Controls/CoreInterop.cs
@@ -1,0 +1,18 @@
+using ColorPicker.Core;
+
+namespace ColorPicker.Controls;
+
+internal static class CoreInterop
+{
+    public static HslaColor ToHsla(this Color c)
+        => new(c.GetHue(), c.GetSaturation(), c.GetLuminosity(), c.Alpha);
+
+    public static Color ToMauiColor(this HslaColor h)
+        => Color.FromHsla(h.H, h.S, h.L, h.A);
+
+    public static RgbaColor ToRgba(this Color c)
+        => new(c.Red, c.Green, c.Blue, c.Alpha);
+
+    public static Color ToMauiColor(this RgbaColor r)
+        => Color.FromRgba(r.R, r.G, r.B, r.A);
+}

--- a/ColorPicker/Controls/HslSliderFactory.cs
+++ b/ColorPicker/Controls/HslSliderFactory.cs
@@ -1,19 +1,25 @@
+using ColorPicker.Core;
+
 namespace ColorPicker.Controls;
 
 public static class HslSliderFactory
 {
-    public static float NewValueH(Color color) => color.GetHue();
-    public static float NewValueS(Color color) => color.GetSaturation();
-    public static float NewValueL(Color color) => color.GetLuminosity();
+    static readonly HueSlider             _hue = new();
+    static readonly SaturationSlider      _sat = new();
+    static readonly Core.LuminositySlider _lum = new();
+
+    public static float NewValueH(Color color) => (float)_hue.Read(color.ToHsla());
+    public static float NewValueS(Color color) => (float)_sat.Read(color.ToHsla());
+    public static float NewValueL(Color color) => (float)_lum.Read(color.ToHsla());
 
     public static Color GetNewColorH(float newValue, Color oldColor)
-            => Color.FromHsla(newValue, oldColor.GetSaturation(), oldColor.GetLuminosity(), oldColor.Alpha);
+            => _hue.Write(oldColor.ToHsla(), newValue).ToMauiColor();
 
     public static Color GetNewColorS(float newValue, Color oldColor)
-            => Color.FromHsla(oldColor.GetHue(), newValue, oldColor.GetLuminosity(), oldColor.Alpha);
+            => _sat.Write(oldColor.ToHsla(), newValue).ToMauiColor();
 
     public static Color GetNewColorL(float newValue, Color oldColor)
-            => Color.FromHsla(oldColor.GetHue(), oldColor.GetSaturation(), newValue, oldColor.Alpha);
+            => _lum.Write(oldColor.ToHsla(), newValue).ToMauiColor();
 
     public static SKPaint GetPaintH(Color _, SKPoint startPoint, SKPoint endPoint)
     {

--- a/ColorPicker/Controls/RgbSliderFactory.cs
+++ b/ColorPicker/Controls/RgbSliderFactory.cs
@@ -1,19 +1,25 @@
+using ColorPicker.Core;
+
 namespace ColorPicker.Controls;
 
 public static class RgbSliderFactory
 {
-    public static float NewValueR(Color color) => color.Red;
-    public static float NewValueG(Color color) => color.Green;
-    public static float NewValueB(Color color) => color.Blue;
+    static readonly RedSlider   _red   = new();
+    static readonly GreenSlider _green = new();
+    static readonly BlueSlider  _blue  = new();
+
+    public static float NewValueR(Color color) => (float)_red  .Read(color.ToRgba());
+    public static float NewValueG(Color color) => (float)_green.Read(color.ToRgba());
+    public static float NewValueB(Color color) => (float)_blue .Read(color.ToRgba());
 
     public static Color GetNewColorR(float newValue, Color oldColor)
-            => Color.FromRgba(newValue, oldColor.Green, oldColor.Blue, oldColor.Alpha);
+            => _red.Write(oldColor.ToRgba(), newValue).WithA(oldColor.Alpha).ToMauiColor();
 
     public static Color GetNewColorG(float newValue, Color oldColor)
-            => Color.FromRgba(oldColor.Red, newValue, oldColor.Blue, oldColor.Alpha);
+            => _green.Write(oldColor.ToRgba(), newValue).WithA(oldColor.Alpha).ToMauiColor();
 
     public static Color GetNewColorB(float newValue, Color oldColor)
-            => Color.FromRgba(oldColor.Red, oldColor.Green, newValue, oldColor.Alpha);
+            => _blue.Write(oldColor.ToRgba(), newValue).WithA(oldColor.Alpha).ToMauiColor();
 
     public static SKPaint GetPaintR(Color color, SKPoint startPoint, SKPoint endPoint)
     {


### PR DESCRIPTION
Embeds Core sources (via <Compile Include>) into ColorPicker.csproj and routes every control's math through Core: HSL/RGB/Alpha sliders, ColorDisc (HS disc + L ring), ColorTriangleArea (SV triangle + hue ring). MAUI controls now own rendering + platform plumbing only.

Single-NuGet packaging preserved; Core remains independently testable. Can be promoted to a separate package later by swapping the Compile Include for a ProjectReference.

**Local verification:** 1335/1335 Core unit tests pass; 213/213 UI tests pass.