### PR TITLE
test: regression coverage for rotating-triangle hue-drag S/L drift

### DIFF
--- a/ColorPicker.UITests/PageObjects/MainPage.cs
+++ b/ColorPicker.UITests/PageObjects/MainPage.cs
@@ -167,6 +167,49 @@ public sealed class MainPage
         _driver.PerformActions(new List<ActionSequence> { seq });
     }
 
+    /// <summary>Drag along a circular arc inside the centered square of a control.
+    /// Used to exercise the hue ring of ColorTriangle / ColorDisc with many touch
+    /// samples per drag — needed to reproduce per-event accumulation bugs.
+    /// </summary>
+    /// <param name="element">Host element.</param>
+    /// <param name="radius">Radius as fraction of half-side (0..1). 0.95 ≈ rim.</param>
+    /// <param name="startDeg">Start angle in degrees (0=right, CCW positive).</param>
+    /// <param name="endDeg">End angle in degrees.</param>
+    /// <param name="segments">Number of straight chord segments (more = smoother + more touch events).</param>
+    /// <param name="totalMs">Total drag duration; each segment gets totalMs/segments.</param>
+    public void DragArcInsideSquare(AppiumElement element,
+        double radius, double startDeg, double endDeg,
+        int segments, int totalMs)
+    {
+        var loc = element.Location;
+        var size = element.Size;
+        var side = Math.Min(size.Width, size.Height);
+        var cx = loc.X + size.Width  / 2.0;
+        var cy = loc.Y + size.Height / 2.0;
+        var r  = side / 2.0 * radius;
+
+        int Px(double deg) => (int)Math.Round(cx + r * Math.Cos(deg * Math.PI / 180.0));
+        int Py(double deg) => (int)Math.Round(cy + r * Math.Sin(deg * Math.PI / 180.0));
+
+        var finger = new PointerInputDevice(PointerKind.Touch, "finger");
+        var seq = new ActionSequence(finger, 0);
+        seq.AddAction(finger.CreatePointerMove(CoordinateOrigin.Viewport,
+            Px(startDeg), Py(startDeg), TimeSpan.Zero));
+        seq.AddAction(finger.CreatePointerDown(MouseButton.Left));
+
+        var perSeg = TimeSpan.FromMilliseconds(Math.Max(1, totalMs / segments));
+        for (int i = 1; i <= segments; i++)
+        {
+            var t = (double)i / segments;
+            var deg = startDeg + (endDeg - startDeg) * t;
+            seq.AddAction(finger.CreatePointerMove(CoordinateOrigin.Viewport,
+                Px(deg), Py(deg), perSeg));
+        }
+
+        seq.AddAction(finger.CreatePointerUp(MouseButton.Left));
+        _driver.PerformActions(new List<ActionSequence> { seq });
+    }
+
     private AppiumElement Find(string automationId) =>
         (AppiumElement)_driver.FindElement(MobileBy.AccessibilityId(automationId));
 

--- a/ColorPicker.UITests/Tests/TriangleHueDriftTests.cs
+++ b/ColorPicker.UITests/Tests/TriangleHueDriftTests.cs
@@ -1,0 +1,100 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using ColorPicker.UITests.Infrastructure;
+
+namespace ColorPicker.UITests.Tests;
+
+/// <summary>
+/// Regression test for the rotating-triangle hue-drag S/L drift bug fixed in
+/// PR #36. Symptom: when <c>RotateTriangleByHue</c> is enabled, every touch
+/// event on the hue ring used to re-decode BOTH H and S/V through the
+/// triangle's pixel-quantized round-trip. Slow drags accumulated quantization
+/// noise into Saturation/Luminosity. Fix: split UpdateColors so a hue-ring
+/// drag only re-decodes hue, leaving S/L untouched.
+/// </summary>
+[Collection(AppiumServerCollection.Name)]
+public sealed class TriangleHueDriftTests : IClassFixture<AppFixture>
+{
+    private readonly AppFixture _fx;
+    public TriangleHueDriftTests(AppFixture fx) => _fx = fx;
+
+    [Fact]
+    public void DraggingHueRing_DoesNotDriftSaturationAndLuminosity()
+    {
+        var triangleWasOn = _fx.Page.IsToggleOn("ShowTriangleSwitch");
+        if (!triangleWasOn) _fx.Page.Toggle(_fx.Page.ShowTriangleSwitch);
+
+        // The RotateTriangleByHue switch is only visible when ShowTriangle is on,
+        // so we must read it after toggling the triangle on.
+        var rotateWasOn = _fx.Page.IsToggleOn("RotateTriangleByHue");
+
+        try
+        {
+            if (!rotateWasOn) _fx.Page.Toggle(_fx.Page.RotateTriangleByHueSwitch);
+
+            // Seed a mid-range S/L by tapping the SV triangle interior.
+            // A point a bit below the hue ring centre lands well inside the
+            // active triangle area regardless of current hue rotation.
+            _fx.Page.TapInsideSquare(_fx.Page.ColorTriangle, 0.50, 0.55);
+            Thread.Sleep(200);
+
+            var hsla0 = ParseHsla(_fx.Page.SelectedColorHsla);
+
+            // Drag a long arc along the hue ring (rim ≈ 0.95 of half-side).
+            // Many short segments ⇒ many touch samples ⇒ the buggy code
+            // accumulates measurable drift; the fixed code stays stable.
+            // Sweep almost two full revolutions to maximize per-event noise.
+            for (int pass = 0; pass < 3; pass++)
+            {
+                _fx.Page.DragArcInsideSquare(_fx.Page.ColorTriangle,
+                    radius: 0.95, startDeg: 20, endDeg: 340,
+                    segments: 80, totalMs: 800);
+                Thread.Sleep(50);
+            }
+            Thread.Sleep(300);
+
+            var hsla1 = ParseHsla(_fx.Page.SelectedColorHsla);
+
+            // Sanity: hue actually moved (otherwise we didn't hit the ring).
+            Assert.True(Math.Abs(hsla1.H - hsla0.H) > 10,
+                $"Hue did not change as expected: H0={hsla0.H}, H1={hsla1.H} (HSLA0={hsla0.Raw}, HSLA1={hsla1.Raw})");
+
+            // Bug repro produced multi-percent S/L drift; the fix keeps S/L
+            // pixel-stable. Tolerance set to catch any non-trivial regression
+            // while tolerating sub-percent rounding in the HSLA readout.
+            const double tol = 0.015;
+            var dS = Math.Abs(hsla1.S - hsla0.S);
+            var dL = Math.Abs(hsla1.L - hsla0.L);
+            Assert.True(dS <= tol,
+                $"Saturation drifted: S0={hsla0.S:F3}, S1={hsla1.S:F3} (HSLA0={hsla0.Raw}, HSLA1={hsla1.Raw})");
+            Assert.True(dL <= tol,
+                $"Luminosity drifted: L0={hsla0.L:F3}, L1={hsla1.L:F3} (HSLA0={hsla0.Raw}, HSLA1={hsla1.Raw})");
+        }
+        finally
+        {
+            if (_fx.Page.IsToggleOn("RotateTriangleByHue") != rotateWasOn)
+                _fx.Page.Toggle(_fx.Page.RotateTriangleByHueSwitch);
+            if (_fx.Page.IsToggleOn("ShowTriangleSwitch") != triangleWasOn)
+                _fx.Page.Toggle(_fx.Page.ShowTriangleSwitch);
+        }
+    }
+
+    private readonly record struct Hsla(double H, double S, double L, double A, string Raw);
+
+    /// <summary>Parse MAUI's Color.ToHslaString() output, e.g. "hsla(354, 100%, 50%, 1)".</summary>
+    private static Hsla ParseHsla(string text)
+    {
+        var m = Regex.Match(text ?? string.Empty,
+            @"hsla?\(\s*([\d.+-]+)\s*,\s*([\d.+-]+)%?\s*,\s*([\d.+-]+)%?\s*(?:,\s*([\d.+-]+))?\s*\)",
+            RegexOptions.IgnoreCase);
+        if (!m.Success)
+            throw new FormatException($"Unrecognized HSLA string: '{text}'");
+
+        var ci = CultureInfo.InvariantCulture;
+        double h = double.Parse(m.Groups[1].Value, ci);
+        double s = double.Parse(m.Groups[2].Value, ci) / 100.0;
+        double l = double.Parse(m.Groups[3].Value, ci) / 100.0;
+        double a = m.Groups[4].Success ? double.Parse(m.Groups[4].Value, ci) : 1.0;
+        return new Hsla(h, s, l, a, text!);
+    }
+}


### PR DESCRIPTION
Adds a UI regression test for the bug fixed in #36 (rotating triangle hue-ring drag could drift S/L because every touch re-decoded both the hue ring AND the SV indicator through the triangle's pixel-quantized roundtrip).

## What's added
- **TriangleHueDriftTests.DraggingHueRing_DoesNotDriftSaturationAndLuminosity** — enables the rotating triangle, seeds a mid-range S/L, then drives multi-segment arc drags along the hue ring (radius ≈ 0.95, 240 touch samples across three sweeps). Asserts |ΔS|, |ΔL| ≤ 0.015 and that hue actually moved.
- **MainPage.DragArcInsideSquare** — reusable helper that composes many short pointer-move segments into a circular arc. Useful for any future hue-ring tests.

## Notes
- The exact original symptom is timing-dependent (touch event rate vs. repaint rate), so this test asserts the post-fix **invariant** — 'hue drag must not move S/L' — rather than trying to reproduce the precise quantization-drift conditions. It guards against any future change that re-merges the two touch paths or otherwise re-decodes SV on a hue-ring event.
- Passes locally against the current (fixed) code. Tolerance is tight enough to catch any non-trivial regression while absorbing the ±1% rounding of the HSLA readout label.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>