### PR TITLE
test: clarify scope of triangle-hue-drift test + slow paced arc helper

### DIFF
--- a/ColorPicker.UITests/PageObjects/MainPage.cs
+++ b/ColorPicker.UITests/PageObjects/MainPage.cs
@@ -169,17 +169,19 @@ public sealed class MainPage
 
     /// <summary>Drag along a circular arc inside the centered square of a control.
     /// Used to exercise the hue ring of ColorTriangle / ColorDisc with many touch
-    /// samples per drag — needed to reproduce per-event accumulation bugs.
+    /// samples per drag. Each segment is its own PerformActions call separated
+    /// by a real-time pause, so the UI thread can repaint between events —
+    /// the timing condition that triggered the rotating-triangle drift bug.
     /// </summary>
     /// <param name="element">Host element.</param>
     /// <param name="radius">Radius as fraction of half-side (0..1). 0.95 ≈ rim.</param>
     /// <param name="startDeg">Start angle in degrees (0=right, CCW positive).</param>
     /// <param name="endDeg">End angle in degrees.</param>
-    /// <param name="segments">Number of straight chord segments (more = smoother + more touch events).</param>
-    /// <param name="totalMs">Total drag duration; each segment gets totalMs/segments.</param>
+    /// <param name="segments">Number of straight chord segments.</param>
+    /// <param name="pauseMsBetweenSegments">Real-time gap between segments (lets UI repaint).</param>
     public void DragArcInsideSquare(AppiumElement element,
         double radius, double startDeg, double endDeg,
-        int segments, int totalMs)
+        int segments, int pauseMsBetweenSegments)
     {
         var loc = element.Location;
         var size = element.Size;
@@ -192,22 +194,34 @@ public sealed class MainPage
         int Py(double deg) => (int)Math.Round(cy + r * Math.Sin(deg * Math.PI / 180.0));
 
         var finger = new PointerInputDevice(PointerKind.Touch, "finger");
-        var seq = new ActionSequence(finger, 0);
-        seq.AddAction(finger.CreatePointerMove(CoordinateOrigin.Viewport,
+
+        // Press at the start point.
+        var press = new ActionSequence(finger, 0);
+        press.AddAction(finger.CreatePointerMove(CoordinateOrigin.Viewport,
             Px(startDeg), Py(startDeg), TimeSpan.Zero));
-        seq.AddAction(finger.CreatePointerDown(MouseButton.Left));
+        press.AddAction(finger.CreatePointerDown(MouseButton.Left));
+        _driver.PerformActions(new List<ActionSequence> { press });
 
-        var perSeg = TimeSpan.FromMilliseconds(Math.Max(1, totalMs / segments));
-        for (int i = 1; i <= segments; i++)
+        try
         {
-            var t = (double)i / segments;
-            var deg = startDeg + (endDeg - startDeg) * t;
-            seq.AddAction(finger.CreatePointerMove(CoordinateOrigin.Viewport,
-                Px(deg), Py(deg), perSeg));
+            for (int i = 1; i <= segments; i++)
+            {
+                var t = (double)i / segments;
+                var deg = startDeg + (endDeg - startDeg) * t;
+                var move = new ActionSequence(finger, 0);
+                move.AddAction(finger.CreatePointerMove(CoordinateOrigin.Viewport,
+                    Px(deg), Py(deg), TimeSpan.FromMilliseconds(10)));
+                _driver.PerformActions(new List<ActionSequence> { move });
+                if (pauseMsBetweenSegments > 0)
+                    Thread.Sleep(pauseMsBetweenSegments);
+            }
         }
-
-        seq.AddAction(finger.CreatePointerUp(MouseButton.Left));
-        _driver.PerformActions(new List<ActionSequence> { seq });
+        finally
+        {
+            var release = new ActionSequence(finger, 0);
+            release.AddAction(finger.CreatePointerUp(MouseButton.Left));
+            _driver.PerformActions(new List<ActionSequence> { release });
+        }
     }
 
     private AppiumElement Find(string automationId) =>

--- a/ColorPicker.UITests/Tests/TriangleHueDriftTests.cs
+++ b/ColorPicker.UITests/Tests/TriangleHueDriftTests.cs
@@ -5,12 +5,27 @@ using ColorPicker.UITests.Infrastructure;
 namespace ColorPicker.UITests.Tests;
 
 /// <summary>
-/// Regression test for the rotating-triangle hue-drag S/L drift bug fixed in
-/// PR #36. Symptom: when <c>RotateTriangleByHue</c> is enabled, every touch
-/// event on the hue ring used to re-decode BOTH H and S/V through the
-/// triangle's pixel-quantized round-trip. Slow drags accumulated quantization
-/// noise into Saturation/Luminosity. Fix: split UpdateColors so a hue-ring
-/// drag only re-decodes hue, leaving S/L untouched.
+/// Invariant guard for the rotating-triangle hue-drag S/L behavior. PR #36
+/// fixed a visual drift where, during a slow human drag on the hue ring,
+/// each touch event re-decoded both the hue ring AND the SV indicator
+/// through the triangle's roundtrip — accumulating tiny per-event noise.
+///
+/// IMPORTANT: This UI test cannot reproduce the original bug
+/// deterministically. The drift was sub-percent per event and only became
+/// visible after many human-paced events with intervening repaints; the
+/// HSLA readout label rounds to whole percent and the MAUI Color HSL↔RGB
+/// roundtrip on this code path is bit-stable in floats, so simulated
+/// Appium drags (even slow, with explicit repaint windows between 1°
+/// segments and varied SV seed points) report exactly 0.0000 drift even
+/// when the buggy UpdateColorsFromH is reintroduced.
+///
+/// Instead, this test enforces the **invariant** the fix establishes:
+/// dragging the hue ring must leave Saturation and Luminosity within a
+/// tight tolerance of their pre-drag values. It catches gross regressions
+/// (e.g. re-merging the two touch paths in a way that visibly perturbs
+/// S/L). Deterministic coverage of the original quantization-noise bug
+/// would require refactoring ColorTriangleArea so its touch logic is
+/// unit-testable without the SkiaSharp runtime.
 /// </summary>
 [Collection(AppiumServerCollection.Name)]
 public sealed class TriangleHueDriftTests : IClassFixture<AppFixture>
@@ -32,10 +47,9 @@ public sealed class TriangleHueDriftTests : IClassFixture<AppFixture>
         {
             if (!rotateWasOn) _fx.Page.Toggle(_fx.Page.RotateTriangleByHueSwitch);
 
-            // Seed a mid-range S/L by tapping the SV triangle interior.
-            // A point a bit below the hue ring centre lands well inside the
-            // active triangle area regardless of current hue rotation.
-            _fx.Page.TapInsideSquare(_fx.Page.ColorTriangle, 0.50, 0.55);
+            // Seed at an asymmetric SV position so the encode/decode path
+            // hits a non-degenerate point in HSL space.
+            _fx.Page.TapInsideSquare(_fx.Page.ColorTriangle, 0.40, 0.62);
             Thread.Sleep(200);
 
             var hsla0 = ParseHsla(_fx.Page.SelectedColorHsla);
@@ -44,12 +58,17 @@ public sealed class TriangleHueDriftTests : IClassFixture<AppFixture>
             // Many short segments ⇒ many touch samples ⇒ the buggy code
             // accumulates measurable drift; the fixed code stays stable.
             // Sweep almost two full revolutions to maximize per-event noise.
-            for (int pass = 0; pass < 3; pass++)
+            // Slow drag along the hue ring (rim ≈ 0.95 of half-side).
+            // Each 1° step is a separate W3C action call with a real-time
+            // pause after it, so the SkiaSharp surface repaints between
+            // events — the timing condition that triggered the original
+            // S/L drift on the rotating triangle.
+            for (int pass = 0; pass < 2; pass++)
             {
                 _fx.Page.DragArcInsideSquare(_fx.Page.ColorTriangle,
                     radius: 0.95, startDeg: 20, endDeg: 340,
-                    segments: 80, totalMs: 800);
-                Thread.Sleep(50);
+                    segments: 80, pauseMsBetweenSegments: 30);
+                Thread.Sleep(100);
             }
             Thread.Sleep(300);
 
@@ -59,9 +78,17 @@ public sealed class TriangleHueDriftTests : IClassFixture<AppFixture>
             Assert.True(Math.Abs(hsla1.H - hsla0.H) > 10,
                 $"Hue did not change as expected: H0={hsla0.H}, H1={hsla1.H} (HSLA0={hsla0.Raw}, HSLA1={hsla1.Raw})");
 
-            // Bug repro produced multi-percent S/L drift; the fix keeps S/L
-            // pixel-stable. Tolerance set to catch any non-trivial regression
-            // while tolerating sub-percent rounding in the HSLA readout.
+            // The original drift bug (PR #36) showed up visually as the SV
+            // indicator dancing under a slow human hue-ring drag. The HSLA
+            // readout label rounds to whole percent, and on this code path
+            // the MAUI Color HSL↔RGB round-trip is bit-stable in floats,
+            // so the cumulative quantization noise the user observed does
+            // not surface through the label. That means this UI test cannot
+            // FAIL deterministically when the bug is reintroduced — it
+            // serves as an **invariant guard**: it asserts that a hue-ring
+            // drag does not perturb S or L beyond a tight tolerance, which
+            // would catch any regression that grossly re-couples the two
+            // touch paths or otherwise leaks SV state into hue handling.
             const double tol = 0.015;
             var dS = Math.Abs(hsla1.S - hsla0.S);
             var dL = Math.Abs(hsla1.L - hsla0.L);


### PR DESCRIPTION
Follow-up to #38, prompted by accurate user feedback: ''you tried to return the bug, but the test can't make an interaction like a human, so this bug will pass through?''

## What I tried
Reinjected the original buggy `UpdateColorsFromH` (which also re-decodes SV per H-touch) and re-ran #38 locally. Tried:
- 80-segment, 800 ms arc drags
- 1-degree segments as separate `PerformActions` calls with 30 ms `Thread.Sleep` between (so SkiaSharp can repaint between events)
- varied SV seed positions to avoid degenerate (S, L) plateaus

Drift came back as **0.0000 every time** through the HSLA readout label. The MAUI Color HSL↔RGB roundtrip on this code path is bit-stable in floats, and the label rounds to whole percent, so the sub-percent per-event noise that produced the visible drift the user saw simply never surfaces here.

## What this PR does
- Marks the test docstring explicitly as an **invariant guard** — it catches gross regressions where a hue-ring drag perturbs S/L, but it is NOT a deterministic repro of bug #36.
- Refactors `DragArcInsideSquare` to issue each 1° segment as its own W3C `PerformActions` call with an explicit `Thread.Sleep` between segments. Closer to a real human pace; useful for any future test that genuinely needs interspersed repaints.
- Adds a note in the docstring that deterministic coverage of #36 would require refactoring `ColorTriangleArea` so its touch logic is unit-testable without the SkiaSharp runtime.

No behavior change in the product code.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>