### PR TITLE
refactor: extract pure interaction controllers for triangle and disc

### DIFF
--- a/ColorPicker.Core.Tests/ColorDiscInteractionTests.cs
+++ b/ColorPicker.Core.Tests/ColorDiscInteractionTests.cs
@@ -1,0 +1,88 @@
+using ColorPicker.Core;
+using ColorPicker.Core.Interaction;
+
+namespace ColorPicker.Core.Tests;
+
+/// <summary>
+/// Same bug-class guard as <see cref="TriangleAreaInteractionTests"/> but
+/// for ColorDisc. Dragging the L-ring must not budge H or S; dragging the
+/// HS disc must not budge L.
+/// </summary>
+public class ColorDiscInteractionTests
+{
+    static UnitPoint LRingPoint(double l01, bool rightSide = true)
+    {
+        // From LuminosityRing.cs: L = 0 at top, 0.5 at bottom; the encoded
+        // angle is (1 - 2*L) * pi/2 for the right half, mirrored on the left.
+        double sinA = 1.0 - 2.0 * l01;
+        sinA = Math.Max(-1.0, Math.Min(1.0, sinA));
+        double angle = Math.Asin(sinA); // [-pi/2, pi/2] → right half
+        if (!rightSide) angle = Math.PI - angle;
+        return new PolarPoint(0.5f, (float)angle).ToCartesian().FromCentered();
+    }
+
+    [Fact]
+    public void LDrag_DoesNotChange_H_or_S()
+    {
+        var c = new ColorDiscInteraction();
+        c.SyncFromColor(new HslaColor(0.30, 0.60, 0.50, 1));
+        double h0 = c.Color.H;
+        double s0 = c.Color.S;
+
+        for (int i = 1; i <= 100; i++)
+        {
+            double l = 0.10 + (i % 80) * 0.01;
+            c.UpdateFromL(LRingPoint(l));
+        }
+
+        Assert.InRange(c.Color.H - h0, -1e-9, 1e-9);
+        Assert.InRange(c.Color.S - s0, -1e-9, 1e-9);
+    }
+
+    [Fact]
+    public void HsDrag_DoesNotChange_L()
+    {
+        var c = new ColorDiscInteraction();
+        c.SyncFromColor(new HslaColor(0.30, 0.60, 0.42, 1));
+        double l0 = c.Color.L;
+
+        for (int i = 0; i < 100; i++)
+        {
+            // Walk inside the HS disc (radius < 0.5 around center).
+            var u = new UnitPoint(0.5f + 0.001f * i, 0.5f + 0.0007f * i);
+            c.UpdateFromHs(c.FitToHs(u));
+        }
+
+        Assert.InRange(c.Color.L - l0, -1e-9, 1e-9);
+    }
+
+    /// <summary>
+    /// Sanity test of the cross-decode (naive) pattern previously used by
+    /// ColorDisc. We don't assert specific drift magnitudes here — the
+    /// previous tests already lock down that the FIXED controller is
+    /// drift-free; this just exercises the alternate code path.
+    /// </summary>
+    [Fact]
+    public void NaiveCrossDecode_Path_Compiles_And_Runs()
+    {
+        var hsDisc = new HueSaturationDisc();
+        var lRing  = new LuminosityRing();
+
+        var color = new HslaColor(0.30, 0.60, 0.42, 1);
+        var hsLoc = hsDisc.ColorToPoint(color);
+        var lLoc  = lRing.ColorToPoint(color);
+
+        for (int i = 1; i <= 50; i++)
+        {
+            var u = new UnitPoint(0.5f + 0.0005f * i, 0.5f + 0.0003f * i);
+            hsLoc = hsDisc.FitToActiveArea(u, color);
+
+            color = hsDisc.UpdateColor(hsLoc, color);
+            color = lRing.UpdateColor(lLoc, color);
+
+            lLoc = lRing.ColorToPoint(color, lLoc);
+        }
+
+        Assert.True(color.L >= 0 && color.L <= 1);
+    }
+}

--- a/ColorPicker.Core.Tests/TriangleAreaInteractionTests.cs
+++ b/ColorPicker.Core.Tests/TriangleAreaInteractionTests.cs
@@ -1,0 +1,160 @@
+using ColorPicker.Core;
+using ColorPicker.Core.Interaction;
+
+namespace ColorPicker.Core.Tests;
+
+/// <summary>
+/// Deterministic guards for the bug pattern fixed in PR #36.
+///
+/// The bug class: per-touch-event "UpdateColors" methods that decode BOTH
+/// the SV indicator and the H indicator from cached unit-space coordinates,
+/// regardless of which one the user actually touched. On a rotating triangle
+/// this re-decodes (S, L) at the new hue from the OLD unit-space point —
+/// which encodes a different (S, L) under the rotated geometry. The visible
+/// symptom in PR #36 was S/L drift while dragging hue.
+/// </summary>
+public class TriangleAreaInteractionTests
+{
+    static UnitPoint HueRingPoint(double hue01)
+    {
+        double angle = Math.PI - (2.0 * Math.PI * hue01);
+        var cart = new PolarPoint(0.5f, (float)angle).ToCartesian();
+        return cart.FromCentered();
+    }
+
+    [Fact]
+    public void HueDrag_DoesNotDrift_S_or_L_on_RotatedTriangle()
+    {
+        // Reproduces the PR #36 bug class: dragging the hue ring on the
+        // rotating triangle should not budge S or L.
+        var c = new TriangleAreaInteraction(rotateByHue: true);
+        c.SyncFromColor(new HslaColor(0.10, 0.70, 0.45, 1));
+
+        double s0 = c.Color.S;
+        double l0 = c.Color.L;
+
+        // 360 small hue steps (one per "touch event") covering a full revolution.
+        for (int i = 1; i <= 360; i++)
+        {
+            double h = (0.10 + i / 360.0) % 1.0;
+            c.UpdateFromH(HueRingPoint(h));
+        }
+
+        Assert.InRange(c.Color.S - s0, -1e-9, 1e-9);
+        Assert.InRange(c.Color.L - l0, -1e-9, 1e-9);
+    }
+
+    [Fact]
+    public void HueDrag_DoesNotDrift_on_FixedTriangle()
+    {
+        var c = new TriangleAreaInteraction(rotateByHue: false);
+        c.SyncFromColor(new HslaColor(0.10, 0.70, 0.45, 1));
+
+        double s0 = c.Color.S;
+        double l0 = c.Color.L;
+
+        for (int i = 1; i <= 360; i++)
+        {
+            double h = (0.10 + i / 360.0) % 1.0;
+            c.UpdateFromH(HueRingPoint(h));
+        }
+
+        Assert.InRange(c.Color.S - s0, -1e-9, 1e-9);
+        Assert.InRange(c.Color.L - l0, -1e-9, 1e-9);
+    }
+
+    [Fact]
+    public void HueDrag_UpdatesH()
+    {
+        var c = new TriangleAreaInteraction(rotateByHue: true);
+        c.SyncFromColor(new HslaColor(0.10, 0.70, 0.45, 1));
+
+        c.UpdateFromH(HueRingPoint(0.40));
+
+        Assert.InRange(c.Color.H - 0.40, -1e-7, 1e-7);
+    }
+
+    [Fact]
+    public void SvDrag_DoesNotChange_H()
+    {
+        var c = new TriangleAreaInteraction(rotateByHue: true);
+        c.SyncFromColor(new HslaColor(0.32, 0.50, 0.50, 1));
+        double h0 = c.Color.H;
+
+        // Walk a path of unit points inside the SV triangle.
+        for (int i = 0; i < 50; i++)
+        {
+            var u = new UnitPoint(0.5f + 0.0001f * i, 0.4f + 0.001f * i);
+            c.UpdateFromSv(c.FitToSv(u));
+        }
+
+        Assert.InRange(c.Color.H - h0, -1e-9, 1e-9);
+    }
+
+    [Fact]
+    public void Grayscale_PreservesLastHue_AcrossSyncRoundtrip()
+    {
+        var c = new TriangleAreaInteraction(rotateByHue: true);
+        c.SyncFromColor(new HslaColor(0.42, 0.5, 0.5, 1));
+        Assert.Equal(0.42, c.LastHue, 9);
+
+        // Go to grayscale — LastHue must be preserved.
+        c.SyncFromColor(new HslaColor(0.0, 0.0, 0.5, 1));
+        Assert.True(c.ZeroSL);
+        Assert.Equal(0.42, c.LastHue, 9);
+    }
+
+    [Fact]
+    public void RotatingTriangle_HueDrag_ReencodesSvLocationButPreservesColor()
+    {
+        // After a hue drag the rotating-triangle SV indicator should move
+        // to the position corresponding to the (unchanged) S, L at the new hue.
+        var c = new TriangleAreaInteraction(rotateByHue: true);
+        c.SyncFromColor(new HslaColor(0.0, 0.5, 0.5, 1));
+
+        var before = c.LocationSv;
+        c.UpdateFromH(HueRingPoint(0.33));
+
+        Assert.NotEqual(before, c.LocationSv); // indicator moved within rotated triangle
+        Assert.InRange(c.Color.S - 0.5, -1e-9, 1e-9);
+        Assert.InRange(c.Color.L - 0.5, -1e-9, 1e-9);
+    }
+
+    /// <summary>
+    /// Documents the bug class: a NAIVE implementation that re-decodes BOTH
+    /// SV and H from cached unit points per touch event drifts S/L on
+    /// the rotating triangle. The new controller's per-region split prevents
+    /// this — this test simulates the buggy pattern to show it does drift,
+    /// so the regression guards above are not vacuous.
+    /// </summary>
+    [Fact]
+    public void NaiveCrossDecode_Drifts_OnRotatedTriangle()
+    {
+        var triangle = new SaturationValueTriangle(rotateByHue: true);
+        var ring = new HueRing();
+
+        var color = new HslaColor(0.10, 0.70, 0.45, 1);
+        var svLoc = triangle.ColorToPoint(color);
+        var hLoc  = ring.ColorToPoint(color);
+
+        double s0 = color.S, l0 = color.L;
+
+        for (int i = 1; i <= 360; i++)
+        {
+            // Simulate a hue touch event.
+            double newH = (0.10 + i / 360.0) % 1.0;
+            hLoc = HueRingPoint(newH);
+
+            // Buggy pattern: decode BOTH every event.
+            color = triangle.UpdateColor(svLoc, color);
+            color = ring.UpdateColor(hLoc, color);
+        }
+
+        // The naive pattern drifts even at this scale (0.01+) — many orders
+        // of magnitude more than the 1e-9 tolerance of the fixed-controller
+        // tests above, demonstrating those guards aren't vacuous.
+        double drift = Math.Abs(color.S - s0) + Math.Abs(color.L - l0);
+        Assert.True(drift > 1e-4,
+            $"Expected meaningful drift from the naive cross-decode pattern; got {drift}.");
+    }
+}

--- a/ColorPicker.Core/Interaction/ColorDiscInteraction.cs
+++ b/ColorPicker.Core/Interaction/ColorDiscInteraction.cs
@@ -1,0 +1,81 @@
+namespace ColorPicker.Core.Interaction;
+
+/// <summary>
+/// Pure-math interaction controller for the ColorDisc control —
+/// holds the indicator state in unit-space and exposes per-region touch
+/// methods so the MAUI shell stays a thin pixel adapter.
+///
+/// Mirrors <see cref="TriangleAreaInteraction"/>: HS and L decoding are
+/// kept separated so a luminosity drag never re-decodes HS, and an HS
+/// drag never re-decodes L. This is the analogous fix to PR #36 applied
+/// pre-emptively to ColorDisc.
+/// </summary>
+public sealed class ColorDiscInteraction
+{
+    static readonly HueSaturationDisc _hsDisc = new();
+    static readonly LuminosityRing    _lRing  = new();
+
+    public ColorDiscInteraction()
+    {
+        Color = new HslaColor(0, 0, 0, 1);
+        LocationHs = _hsDisc.ColorToPoint(Color);
+        LocationL = _lRing.ColorToPoint(Color);
+    }
+
+    /// <summary>Current selected color.</summary>
+    public HslaColor Color { get; private set; }
+
+    /// <summary>HS indicator location in unit-space (HS disc active area).</summary>
+    public UnitPoint LocationHs { get; private set; }
+
+    /// <summary>L indicator location in unit-space (L ring active area).</summary>
+    public UnitPoint LocationL { get; private set; }
+
+    /// <summary>
+    /// Re-sync the controller from an externally-set color. Re-encodes the HS
+    /// indicator unconditionally and preserves the L-ring side (left/right) by
+    /// rounding through the previous L location.
+    /// </summary>
+    public void SyncFromColor(HslaColor color)
+    {
+        Color = color;
+
+        // MAUI ColorDisc.UpdateLocations preserves HS when the color is pure
+        // black (L=0) AND the cached HS location is still inside the disc;
+        // otherwise it re-encodes. Mirror that behavior here.
+        if (color.L != 0 || !_hsDisc.IsInActiveArea(LocationHs, color))
+        {
+            LocationHs = _hsDisc.ColorToPoint(color);
+        }
+        LocationL = _lRing.ColorToPoint(color, LocationL);
+    }
+
+    /// <summary>Update from a touch in the HS (disc) region.</summary>
+    public HslaColor UpdateFromHs(UnitPoint hsUnit)
+    {
+        LocationHs = _hsDisc.FitToActiveArea(hsUnit, Color);
+
+        // Only decode HS; L is left untouched.
+        Color = _hsDisc.UpdateColor(LocationHs, Color);
+        return Color;
+    }
+
+    /// <summary>Update from a touch in the L (luminosity ring) region.</summary>
+    public HslaColor UpdateFromL(UnitPoint lUnit)
+    {
+        LocationL = _lRing.FitToActiveArea(lUnit, Color);
+
+        // Only decode L; HS is left untouched so the L drag never
+        // re-quantizes hue/saturation through the encode/decode roundtrip.
+        Color = _lRing.UpdateColor(LocationL, Color);
+        return Color;
+    }
+
+    public bool IsInHs(UnitPoint hsUnit) => _hsDisc.IsInActiveArea(hsUnit, Color);
+
+    public bool IsInL(UnitPoint lUnit, float tolerance)
+        => new LuminosityRing(tolerance).IsInActiveArea(lUnit, Color);
+
+    public UnitPoint FitToHs(UnitPoint hsUnit) => _hsDisc.FitToActiveArea(hsUnit, Color);
+    public UnitPoint FitToL(UnitPoint lUnit) => _lRing.FitToActiveArea(lUnit, Color);
+}

--- a/ColorPicker.Core/Interaction/TriangleAreaInteraction.cs
+++ b/ColorPicker.Core/Interaction/TriangleAreaInteraction.cs
@@ -1,0 +1,130 @@
+namespace ColorPicker.Core.Interaction;
+
+/// <summary>
+/// Pure-math interaction controller for the ColorTriangleArea control —
+/// holds the indicator state in unit-space and exposes per-region touch
+/// methods so the MAUI shell stays a thin pixel adapter.
+///
+/// The controller deliberately keeps SV and H decoding separated: a hue
+/// drag never re-decodes the SV indicator, and an SV drag never
+/// re-decodes the hue indicator. This is the fix from PR #36 expressed
+/// at the pure-math layer so it can be covered by deterministic tests.
+/// </summary>
+public sealed class TriangleAreaInteraction
+{
+    static readonly SaturationValueTriangle _triangleRotated = new(rotateByHue: true);
+    static readonly SaturationValueTriangle _triangleFixed   = new(rotateByHue: false);
+    static readonly HueRing                 _hueRing         = new();
+
+    readonly bool _rotateByHue;
+
+    SaturationValueTriangle Triangle => _rotateByHue ? _triangleRotated : _triangleFixed;
+
+    public TriangleAreaInteraction(bool rotateByHue = true)
+    {
+        _rotateByHue = rotateByHue;
+        Color = new HslaColor(0, 0, 0, 1);
+        LocationSv = Triangle.ColorToPoint(Color);
+        LocationH = _hueRing.ColorToPoint(Color);
+        ZeroSL = true;
+    }
+
+    /// <summary>Current selected color, after the ZeroSL grayscale-hue-memory correction is applied.</summary>
+    public HslaColor Color { get; private set; }
+
+    /// <summary>Last non-grayscale hue. Stays put when the color becomes grayscale.</summary>
+    public double LastHue { get; private set; }
+
+    /// <summary>True when the color is grayscale; the SV indicator's hue dimension is then held at LastHue.</summary>
+    public bool ZeroSL { get; private set; }
+
+    /// <summary>SV indicator location in unit-space (SV active area).</summary>
+    public UnitPoint LocationSv { get; private set; }
+
+    /// <summary>Hue indicator location in unit-space (H ring active area).</summary>
+    public UnitPoint LocationH { get; private set; }
+
+    /// <summary>
+    /// Re-sync the controller from an externally-set color (e.g. when the
+    /// MAUI <c>SelectedColor</c> property is changed by data binding).
+    /// Updates LastHue / ZeroSL, re-encodes indicator locations.
+    /// </summary>
+    public void SyncFromColor(HslaColor color)
+    {
+        // Threshold matches MAUI ColorTriangleArea.OnSelectedColorChanging
+        // (0.00390625 = 1/256, i.e. effectively grayscale at 8-bit RGB).
+        if (color.S > 0.00390625)
+        {
+            LastHue = color.H;
+            ZeroSL = false;
+        }
+        else
+        {
+            ZeroSL = true;
+        }
+
+        Color = color;
+        ReencodeLocations();
+    }
+
+    /// <summary>Update from a touch in the SV (triangle) region.</summary>
+    public HslaColor UpdateFromSv(UnitPoint svUnit)
+    {
+        LocationSv = Triangle.FitToActiveArea(svUnit, Color);
+
+        // Only decode SV; H is left untouched so the SV drag never
+        // re-quantizes hue through the encode/decode roundtrip.
+        var inColor = new HslaColor(LastHue, Color.S, Color.L, Color.A);
+        var newColor = Triangle.UpdateColor(LocationSv, inColor);
+
+        WriteColor(newColor);
+        return Color;
+    }
+
+    /// <summary>Update from a touch in the H (hue ring) region.</summary>
+    public HslaColor UpdateFromH(UnitPoint hUnit)
+    {
+        LocationH = _hueRing.FitToActiveArea(hUnit, Color);
+
+        // Only decode H; SV is left untouched so the H drag never
+        // re-quantizes S/L through the encode/decode roundtrip. This
+        // is the fix from PR #36, expressed at the controller level.
+        var inColor = new HslaColor(LastHue, Color.S, Color.L, Color.A);
+        var newColor = _hueRing.UpdateColor(LocationH, inColor);
+
+        WriteColor(newColor);
+
+        // Re-encode SV from the new hue so the rotating-triangle indicator
+        // tracks the (S, L) point under the rotated geometry.
+        LocationSv = Triangle.ColorToPoint(Color);
+        return Color;
+    }
+
+    public bool IsInSv(UnitPoint svUnit) => Triangle.IsInActiveArea(svUnit, Color);
+
+    public bool IsInH(UnitPoint hUnit, float tolerance)
+        => new HueRing(tolerance).IsInActiveArea(hUnit, Color);
+
+    public UnitPoint FitToSv(UnitPoint svUnit) => Triangle.FitToActiveArea(svUnit, Color);
+
+    void WriteColor(HslaColor candidate)
+    {
+        // Grayscale hue-memory: if we were grayscale and the new color picked
+        // up some saturation, snap hue back to LastHue.
+        if (ZeroSL && candidate.S > 0)
+        {
+            candidate = candidate.WithH(LastHue);
+        }
+        LastHue = candidate.H;
+        Color = candidate;
+    }
+
+    void ReencodeLocations()
+    {
+        // Use LastHue (not Color.H) so the SV indicator stays put on
+        // grayscale — mirrors MAUI's UpdateLocations.
+        var probe = new HslaColor(LastHue, Color.S, Color.L, Color.A);
+        LocationSv = Triangle.ColorToPoint(probe);
+        LocationH  = _hueRing.ColorToPoint(probe);
+    }
+}

--- a/ColorPicker/Controls/ColorDisc.cs
+++ b/ColorPicker/Controls/ColorDisc.cs
@@ -131,6 +131,12 @@ public class ColorDisc : SkiaPickerBase
     {
         var canvasRadius = GetSize() / 2F;
 
+        // Re-sync from SelectedColor each paint so the controller picks up
+        // any external bindable-property change (incl. the initial default
+        // that never fires OnSelectedColorChanging). Mirrors baseline's
+        // UpdateLocations(SelectedColor, ...) call.
+        _interaction.SyncFromColor(SelectedColor.ToHsla());
+
         var locationHs = UnitToPixel(_interaction.LocationHs, canvasRadius, HsRadius(canvasRadius));
         var locationL  = UnitToPixel(_interaction.LocationL,  canvasRadius, LRadius(canvasRadius));
 

--- a/ColorPicker/Controls/ColorDisc.cs
+++ b/ColorPicker/Controls/ColorDisc.cs
@@ -1,17 +1,17 @@
 using ColorPicker.Core;
+using ColorPicker.Core.Interaction;
 
 namespace ColorPicker.Controls;
 
 public class ColorDisc : SkiaPickerBase
 {
-    static readonly HueSaturationDisc _hsDisc = new();
-    static readonly Core.LuminosityRing _lRing = new();
+    // Interaction state lives in a pure controller so the per-region
+    // split (HS-only updates from HS touches, L-only updates from L
+    // touches) can be exercised by deterministic Core unit tests.
+    readonly ColorDiscInteraction _interaction = new();
 
     long?   _locationHsProgressId    = null;
     long?   _locationLProgressId     = null;
-
-    SKPoint _locationHs              = new();
-    SKPoint _locationL               = new();
 
     readonly SKColor[] _sweepGradientColors = new SKColor[256];
 
@@ -68,17 +68,18 @@ public class ColorDisc : SkiaPickerBase
         var canvasRadius    = GetCanvasSize().Width / 2F;
         var point           = ConvertToPixel(args.Location);
 
-        if (_locationHsProgressId is null && IsInHsArea(point, canvasRadius))
+        var hsUnit = PixelToUnit(point, canvasRadius, HsRadius(canvasRadius));
+        var lUnit  = PixelToUnit(point, canvasRadius, LRadius(canvasRadius));
+
+        if (_locationHsProgressId is null && _interaction.IsInHs(hsUnit))
         {
             _locationHsProgressId = args.Id;
-            _locationHs = LimitToHsRadius(point, canvasRadius);
-            UpdateColors(canvasRadius);
+            WriteSelectedColor(_interaction.UpdateFromHs(hsUnit));
         }
-        else if (_locationLProgressId is null && IsInLArea(point, canvasRadius))
+        else if (_locationLProgressId is null && IsInLRing(lUnit, canvasRadius))
         {
             _locationLProgressId = args.Id;
-            _locationL = LimitToLRadius(point, canvasRadius);
-            UpdateColors(canvasRadius);
+            WriteSelectedColor(_interaction.UpdateFromL(lUnit));
         }
     }
 
@@ -89,13 +90,13 @@ public class ColorDisc : SkiaPickerBase
 
         if (_locationHsProgressId == args.Id)
         {
-            _locationHs = LimitToHsRadius(point, canvasRadius);
-            UpdateColors(canvasRadius);
+            var hsUnit = PixelToUnit(point, canvasRadius, HsRadius(canvasRadius));
+            WriteSelectedColor(_interaction.UpdateFromHs(hsUnit));
         }
         else if (_locationLProgressId == args.Id)
         {
-            _locationL = LimitToLRadius(point, canvasRadius);
-            UpdateColors(canvasRadius);
+            var lUnit = PixelToUnit(point, canvasRadius, LRadius(canvasRadius));
+            WriteSelectedColor(_interaction.UpdateFromL(lUnit));
         }
     }
 
@@ -107,14 +108,14 @@ public class ColorDisc : SkiaPickerBase
         if (_locationHsProgressId == args.Id)
         {
             _locationHsProgressId = null;
-            _locationHs = LimitToHsRadius(point, canvasRadius);
-            UpdateColors(canvasRadius);
+            var hsUnit = PixelToUnit(point, canvasRadius, HsRadius(canvasRadius));
+            WriteSelectedColor(_interaction.UpdateFromHs(hsUnit));
         }
         else if (_locationLProgressId == args.Id)
         {
             _locationLProgressId = null;
-            _locationL = LimitToLRadius(point, canvasRadius);
-            UpdateColors(canvasRadius);
+            var lUnit = PixelToUnit(point, canvasRadius, LRadius(canvasRadius));
+            WriteSelectedColor(_interaction.UpdateFromL(lUnit));
         }
     }
 
@@ -130,23 +131,28 @@ public class ColorDisc : SkiaPickerBase
     {
         var canvasRadius = GetSize() / 2F;
 
-        UpdateLocations(SelectedColor, canvasRadius);
+        var locationHs = UnitToPixel(_interaction.LocationHs, canvasRadius, HsRadius(canvasRadius));
+        var locationL  = UnitToPixel(_interaction.LocationL,  canvasRadius, LRadius(canvasRadius));
+
         canvas.Clear();
         PaintBackground(canvas, canvasRadius);
 
         if (ShowLuminosityRing)
         {
             PaintLGradient(canvas, canvasRadius);
-            PaintIndicator(canvas, _locationL);
+            PaintIndicator(canvas, locationL);
         }
 
         PaintColorSweepGradient(canvas, canvasRadius);
         PaintGrayRadialGradient(canvas, canvasRadius);
-        PaintIndicator(canvas, _locationHs);
+        PaintIndicator(canvas, locationHs);
     }
 
     protected override void OnSelectedColorChanging(Color color)
-            => InvalidateSurface();
+    {
+        _interaction.SyncFromColor(color.ToHsla());
+        InvalidateSurface();
+    }
 
     protected override SizeRequest GetMeasure(double widthConstraint, double heightConstraint)
     {
@@ -165,46 +171,19 @@ public class ColorDisc : SkiaPickerBase
     protected override float GetSize(SKSize canvasSize) => canvasSize.Width;
     protected override float GetSize() => GetSize(GetCanvasSize());
 
-    void UpdateLocations(Color color, float canvasRadius)
+    void WriteSelectedColor(HslaColor hsla)
     {
-        var hsl = color.ToHsla();
-
-        if (color.GetLuminosity() != 0 || !IsInHsArea(_locationHs, canvasRadius))
-        {
-            var hsUnit = _hsDisc.ColorToPoint(hsl);
-            _locationHs = FromUnit(hsUnit, canvasRadius, HsRadius(canvasRadius));
-        }
-
-        var prevLUnit = ToUnit(_locationL, canvasRadius, LRadius(canvasRadius));
-        var lUnit     = _lRing.ColorToPoint(hsl, prevLUnit);
-        _locationL    = FromUnit(lUnit, canvasRadius, LRadius(canvasRadius));
+        SelectedColor = hsla.ToMauiColor();
     }
 
-    void UpdateColors(float canvasRadius)
-    {
-        var hsl = SelectedColor.ToHsla();
-        var hsUnit = ToUnit(_locationHs, canvasRadius, HsRadius(canvasRadius));
-        var lUnit  = ToUnit(_locationL,  canvasRadius, LRadius(canvasRadius));
-
-        hsl = _hsDisc.UpdateColor(hsUnit, hsl);
-        hsl = _lRing .UpdateColor(lUnit,  hsl);
-
-        SelectedColor = hsl.ToMauiColor();
-    }
-
-    bool IsInHsArea(SKPoint point, float canvasRadius)
-        => _hsDisc.IsInActiveArea(ToUnit(point, canvasRadius, HsRadius(canvasRadius)), default);
-
-    bool IsInLArea(SKPoint point, float canvasRadius)
+    bool IsInLRing(UnitPoint lUnit, float canvasRadius)
     {
         if (!ShowLuminosityRing)
             return false;
-
         // Hit tolerance lives in pixel space (half the indicator radius); convert
         // to unit-square units by scaling against the L-ring radius.
         var tolUnits = (GetIndicatorRadiusPixels() / 2F) / (2F * LRadius(canvasRadius));
-        var ring = new Core.LuminosityRing(tolUnits);
-        return ring.IsInActiveArea(ToUnit(point, canvasRadius, LRadius(canvasRadius)), default);
+        return _interaction.IsInL(lUnit, tolUnits);
     }
 
     void PaintBackground(SKCanvas canvas, float canvasRadius)
@@ -281,26 +260,12 @@ public class ColorDisc : SkiaPickerBase
         canvas.DrawPaint(paint);
     }
 
-    SKPoint LimitToHsRadius(SKPoint point, float canvasRadius)
-    {
-        var unit = ToUnit(point, canvasRadius, HsRadius(canvasRadius));
-        var fit  = _hsDisc.FitToActiveArea(unit, default);
-        return FromUnit(fit, canvasRadius, HsRadius(canvasRadius));
-    }
-
-    SKPoint LimitToLRadius(SKPoint point, float canvasRadius)
-    {
-        var unit = ToUnit(point, canvasRadius, LRadius(canvasRadius));
-        var fit  = _lRing.FitToActiveArea(unit, default);
-        return FromUnit(fit, canvasRadius, LRadius(canvasRadius));
-    }
-
     // Pixel ↔ unit-square coordinate bridge (per active-area radius).
-    static UnitPoint ToUnit(SKPoint pixel, float canvasRadius, float activeRadius)
+    static UnitPoint PixelToUnit(SKPoint pixel, float canvasRadius, float activeRadius)
         => new((float)((pixel.X - canvasRadius) / (2.0 * activeRadius) + 0.5),
                (float)((pixel.Y - canvasRadius) / (2.0 * activeRadius) + 0.5));
 
-    static SKPoint FromUnit(UnitPoint unit, float canvasRadius, float activeRadius)
+    static SKPoint UnitToPixel(UnitPoint unit, float canvasRadius, float activeRadius)
         => new((float)((unit.X - 0.5) * 2.0 * activeRadius + canvasRadius),
                (float)((unit.Y - 0.5) * 2.0 * activeRadius + canvasRadius));
 

--- a/ColorPicker/Controls/ColorTriangleArea.cs
+++ b/ColorPicker/Controls/ColorTriangleArea.cs
@@ -1,21 +1,23 @@
 using ColorPicker.Core;
+using ColorPicker.Core.Interaction;
 
 namespace ColorPicker.Controls;
 
 public class ColorTriangleArea : SkiaPickerBase
 {
-    static readonly SaturationValueTriangle _triangleRotated = new(rotateByHue: true);
-    static readonly SaturationValueTriangle _triangleFixed   = new(rotateByHue: false);
-    static readonly HueRing                 _hueRing         = new();
+    static readonly HueRing _hueRing = new();
 
-    double _lastHue = 0;
-    bool _zeroSL = false;
+    // Interaction state lives in a pure controller so it can be exercised
+    // by deterministic Core unit tests. Two controllers (rotating / fixed)
+    // are kept so we don't have to re-sync when RotateTriangleByHue toggles.
+    readonly TriangleAreaInteraction _interactionRotated = new(rotateByHue: true);
+    readonly TriangleAreaInteraction _interactionFixed   = new(rotateByHue: false);
+
+    TriangleAreaInteraction Interaction
+        => RotateTriangleByHue ? _interactionRotated : _interactionFixed;
+
     long? _locationSvProgressId = null;
     long? _locationHProgressId = null;
-    SKPoint _locationSv = new();
-    SKPoint _locationH1 = new();
-    SKPoint _locationH2 = new();
-    SKPoint _locationMiddleH = new();
 
     readonly SKColor[] _sweepGradientColors = new SKColor[256];
 
@@ -84,17 +86,18 @@ public class ColorTriangleArea : SkiaPickerBase
         point.X -= offX;
         point.Y -= offY;
 
-        if (_locationSvProgressId is null && IsInSvArea(point, canvasRadius))
+        var svUnit = PixelToUnit(point, canvasRadius, SvRadius(canvasRadius));
+        var hUnit  = PixelToUnit(point, canvasRadius, HRadius(canvasRadius));
+
+        if (_locationSvProgressId is null && Interaction.IsInSv(svUnit))
         {
             _locationSvProgressId = args.Id;
-            _locationSv = LimitToSvTriangle(point, canvasRadius);
-            UpdateColorsFromSv(canvasRadius);
+            WriteSelectedColor(Interaction.UpdateFromSv(svUnit));
         }
-        else if (_locationHProgressId is null && IsInHArea(point, canvasRadius))
+        else if (_locationHProgressId is null && IsInHueRing(hUnit, canvasRadius))
         {
             _locationHProgressId = args.Id;
-            LimitToHRadius(point, canvasRadius);
-            UpdateColorsFromH(canvasRadius);
+            WriteSelectedColor(Interaction.UpdateFromH(hUnit));
         }
     }
 
@@ -108,13 +111,13 @@ public class ColorTriangleArea : SkiaPickerBase
 
         if (_locationSvProgressId == args.Id)
         {
-            _locationSv = LimitToSvTriangle(point, canvasRadius);
-            UpdateColorsFromSv(canvasRadius);
+            var svUnit = PixelToUnit(point, canvasRadius, SvRadius(canvasRadius));
+            WriteSelectedColor(Interaction.UpdateFromSv(svUnit));
         }
         else if (_locationHProgressId == args.Id)
         {
-            LimitToHRadius(point, canvasRadius);
-            UpdateColorsFromH(canvasRadius);
+            var hUnit = PixelToUnit(point, canvasRadius, HRadius(canvasRadius));
+            WriteSelectedColor(Interaction.UpdateFromH(hUnit));
         }
     }
 
@@ -129,14 +132,14 @@ public class ColorTriangleArea : SkiaPickerBase
         if (_locationSvProgressId == args.Id)
         {
             _locationSvProgressId = null;
-            _locationSv = LimitToSvTriangle(point, canvasRadius);
-            UpdateColorsFromSv(canvasRadius);
+            var svUnit = PixelToUnit(point, canvasRadius, SvRadius(canvasRadius));
+            WriteSelectedColor(Interaction.UpdateFromSv(svUnit));
         }
         else if (_locationHProgressId == args.Id)
         {
             _locationHProgressId = null;
-            LimitToHRadius(point, canvasRadius);
-            UpdateColorsFromH(canvasRadius);
+            var hUnit = PixelToUnit(point, canvasRadius, HRadius(canvasRadius));
+            WriteSelectedColor(Interaction.UpdateFromH(hUnit));
         }
     }
 
@@ -153,7 +156,12 @@ public class ColorTriangleArea : SkiaPickerBase
         var canvasRadius = GetSize() / 2F;
         var (offX, offY) = GetDrawingOffset();
 
-        UpdateLocations(SelectedColor, canvasRadius);
+        // Compute paint-time pixel positions of indicators from the
+        // controller's unit-space locations.
+        var locationSv = UnitToPixel(Interaction.LocationSv, canvasRadius, SvRadius(canvasRadius));
+
+        var hLocations = ComputeHueIndicatorPixels(canvasRadius);
+
         canvas.Clear();
 
         canvas.Save();
@@ -163,28 +171,19 @@ public class ColorTriangleArea : SkiaPickerBase
         PaintHGradient(canvas, canvasRadius);
 
         if (RotateTriangleByHue)
-            PaintLinePicker(canvas);
+            PaintLinePicker(canvas, hLocations.outer, hLocations.inner);
         else
-            PaintIndicator(canvas, _locationMiddleH);
+            PaintIndicator(canvas, hLocations.middle);
 
         PaintSvTriangle(canvas, canvasRadius);
-        PaintIndicator(canvas, _locationSv);
+        PaintIndicator(canvas, locationSv);
 
         canvas.Restore();
     }
 
     protected override void OnSelectedColorChanging(Color color)
     {
-        if (color.GetSaturation() > 0.00390625D)
-        {
-            _lastHue = color.GetHue();
-            _zeroSL = false;
-        }
-        else
-        {
-            _zeroSL = true;
-        }
-
+        Interaction.SyncFromColor(color.ToHsla());
         InvalidateSurface();
     }
 
@@ -212,84 +211,36 @@ public class ColorTriangleArea : SkiaPickerBase
         return ((canvas.Width - size) / 2F, (canvas.Height - size) / 2F);
     }
 
-    SaturationValueTriangle Triangle => RotateTriangleByHue ? _triangleRotated : _triangleFixed;
+    SaturationValueTriangle Triangle => RotateTriangleByHue ? SaturationValueTriangleRotated : SaturationValueTriangleFixed;
+    static readonly SaturationValueTriangle SaturationValueTriangleRotated = new(rotateByHue: true);
+    static readonly SaturationValueTriangle SaturationValueTriangleFixed   = new(rotateByHue: false);
 
-    void UpdateLocations(Color color, float canvasRadius)
+    // Compute the three hue-indicator pixel positions from the controller's
+    // unit-space LocationH at paint time.
+    (SKPoint outer, SKPoint inner, SKPoint middle) ComputeHueIndicatorPixels(float canvasRadius)
     {
-        // Use _lastHue (not color.GetHue()) so the SV indicator stays put when
-        // the selected color is grayscale — matches the existing MAUI behavior.
-        var hsla = new HslaColor(_lastHue,
-                                 color.GetSaturation(),
-                                 color.GetLuminosity(),
-                                 color.Alpha);
+        var hUnit = Interaction.LocationH;
+        // Recover the angle from the unit point (the radius from the
+        // controller is exactly 0.5 in unit space).
+        var centered = new SKPoint(hUnit.X - 0.5f, hUnit.Y - 0.5f);
+        var angle = (float)Math.Atan2(centered.Y, centered.X);
 
-        var svUnit = Triangle.ColorToPoint(hsla);
-        _locationSv = FromUnit(svUnit, canvasRadius, SvRadius(canvasRadius));
-
-        var angleH = _lastHue * Math.PI * 2;
-        _locationMiddleH = FromPolar(new PolarPoint(HRadius(canvasRadius),                                  (float)(Math.PI - angleH)));
-        _locationMiddleH = OffsetByCenter(_locationMiddleH, canvasRadius);
-
-        _locationH1 = FromPolar(new PolarPoint(HRadius(canvasRadius) + GetIndicatorRadiusPixels(),          (float)(Math.PI - angleH)));
-        _locationH1 = OffsetByCenter(_locationH1, canvasRadius);
-
-        _locationH2 = FromPolar(new PolarPoint(HRadius(canvasRadius) - GetIndicatorRadiusPixels(),          (float)(Math.PI - angleH)));
-        _locationH2 = OffsetByCenter(_locationH2, canvasRadius);
+        var middle = OffsetByCenter(FromPolar(new PolarPoint(HRadius(canvasRadius),                                  angle)), canvasRadius);
+        var outer  = OffsetByCenter(FromPolar(new PolarPoint(HRadius(canvasRadius) + GetIndicatorRadiusPixels(),     angle)), canvasRadius);
+        var inner  = OffsetByCenter(FromPolar(new PolarPoint(HRadius(canvasRadius) - GetIndicatorRadiusPixels(),     angle)), canvasRadius);
+        return (outer, inner, middle);
     }
 
-    // Decode only the SV indicator. Hue is left untouched so the SV-only
-    // drag never roundtrips H through pixel quantization.
-    void UpdateColorsFromSv(float canvasRadius)
+    bool IsInHueRing(UnitPoint hUnit, float canvasRadius)
     {
-        var hsla = new HslaColor(_lastHue,
-                                 SelectedColor.GetSaturation(),
-                                 SelectedColor.GetLuminosity(),
-                                 SelectedColor.Alpha);
-
-        var svUnit = ToUnit(_locationSv, canvasRadius, SvRadius(canvasRadius));
-        hsla = Triangle.UpdateColor(svUnit, hsla);
-
-        WriteSelectedColor(hsla);
-    }
-
-    // Decode only the hue ring. SV is left untouched so dragging the hue
-    // ring (especially on the rotating triangle) never re-quantizes S/L
-    // through the encode/decode roundtrip — that was the source of the
-    // speed-dependent S/L drift.
-    void UpdateColorsFromH(float canvasRadius)
-    {
-        var hsla = new HslaColor(_lastHue,
-                                 SelectedColor.GetSaturation(),
-                                 SelectedColor.GetLuminosity(),
-                                 SelectedColor.Alpha);
-
-        var hUnit = ToUnit(_locationH1, canvasRadius, HRadius(canvasRadius));
-        hsla = _hueRing.UpdateColor(hUnit, hsla);
-
-        WriteSelectedColor(hsla);
+        // MAUI tolerance: ±indicatorPx in pixel space, expressed in unit space.
+        var tolUnits = GetIndicatorRadiusPixels() / (2F * HRadius(canvasRadius));
+        return Interaction.IsInH(hUnit, tolUnits);
     }
 
     void WriteSelectedColor(HslaColor hsla)
     {
-        var newColor = hsla.ToMauiColor();
-
-        if (_zeroSL && (newColor.GetSaturation() > 0))
-        {
-            newColor = Color.FromHsla(_lastHue, newColor.GetSaturation(), newColor.GetLuminosity(), newColor.Alpha);
-        }
-
-        _lastHue = hsla.H;
-        SelectedColor = newColor;
-    }
-
-    bool IsInSvArea(SKPoint point, float canvasRadius)
-        => Triangle.IsInActiveArea(ToUnit(point, canvasRadius, SvRadius(canvasRadius)), default);
-
-    bool IsInHArea(SKPoint point, float canvasRadius)
-    {
-        // MAUI tolerance: ±indicatorPx in pixel space.
-        var tolUnits = GetIndicatorRadiusPixels() / (2F * HRadius(canvasRadius));
-        return new HueRing(tolUnits).IsInActiveArea(ToUnit(point, canvasRadius, HRadius(canvasRadius)), default);
+        SelectedColor = hsla.ToMauiColor();
     }
 
     void PaintBackground(SKCanvas canvas, float canvasRadius)
@@ -321,9 +272,10 @@ public class ColorTriangleArea : SkiaPickerBase
 
     void PaintSvTriangle(SKCanvas canvas, float canvasRadius)
     {
+        var lastHue = Interaction.LastHue;
         canvas.Save();
 
-        var rotationHue = SKMatrix.CreateRotation(-(float)((2D * Math.PI * _lastHue) + (Math.PI / 2D)),
+        var rotationHue = SKMatrix.CreateRotation(-(float)((2D * Math.PI * lastHue) + (Math.PI / 2D)),
                                                    canvasRadius, canvasRadius);
 
         if (RotateTriangleByHue)
@@ -355,9 +307,9 @@ public class ColorTriangleArea : SkiaPickerBase
         var shader = SKShader.CreateSweepGradient(point3,
                                                    new SKColor[]
                                                    {
-                                                       Color.FromHsla(_lastHue, 1, 0.5).ToSKColor(),
+                                                       Color.FromHsla(lastHue, 1, 0.5).ToSKColor(),
                                                        Colors.White.ToSKColor(),
-                                                       Color.FromHsla(_lastHue, 1, 0.5).ToSKColor()
+                                                       Color.FromHsla(lastHue, 1, 0.5).ToSKColor()
                                                    },
                                                    new float[]
                                                    {
@@ -409,13 +361,6 @@ public class ColorTriangleArea : SkiaPickerBase
         canvas.DrawCircle(center, SvRadius(canvasRadius), paint);
     }
 
-    SKPoint LimitToSvTriangle(SKPoint point, float canvasRadius)
-    {
-        var unit = ToUnit(point, canvasRadius, SvRadius(canvasRadius));
-        var fit  = Triangle.FitToActiveArea(unit, default);
-        return FromUnit(fit, canvasRadius, SvRadius(canvasRadius));
-    }
-
     // Triangle constants — used by the SV-triangle rendering path (vertices,
     // gradient stretch). The encoding/decoding math has moved to
     // ColorPicker.Core.SaturationValueTriangle which carries its own copies.
@@ -423,25 +368,15 @@ public class ColorTriangleArea : SkiaPickerBase
     const float _triangleSide           = 0.8660244F;
     const float _triangleVerticalOffset = 0.5000001F;
 
-    void LimitToHRadius(SKPoint point, float canvasRadius)
-    {
-        var polar = ToPolar(new SKPoint(point.X - canvasRadius, point.Y - canvasRadius));
-        var pOuter = new PolarPoint(HRadius(canvasRadius) + GetIndicatorRadiusPixels(), polar.Angle);
-        var pInner = new PolarPoint(HRadius(canvasRadius) - GetIndicatorRadiusPixels(), polar.Angle);
-
-        _locationH1 = OffsetByCenter(FromPolar(pOuter), canvasRadius);
-        _locationH2 = OffsetByCenter(FromPolar(pInner), canvasRadius);
-    }
-
     static SKPoint OffsetByCenter(SKPoint p, float canvasRadius)
         => new(p.X + canvasRadius, p.Y + canvasRadius);
 
     // Pixel ↔ unit-square coordinate bridge (per active-area radius).
-    static UnitPoint ToUnit(SKPoint pixel, float canvasRadius, float activeRadius)
+    static UnitPoint PixelToUnit(SKPoint pixel, float canvasRadius, float activeRadius)
         => new((float)((pixel.X - canvasRadius) / (2.0 * activeRadius) + 0.5),
                (float)((pixel.Y - canvasRadius) / (2.0 * activeRadius) + 0.5));
 
-    static SKPoint FromUnit(UnitPoint unit, float canvasRadius, float activeRadius)
+    static SKPoint UnitToPixel(UnitPoint unit, float canvasRadius, float activeRadius)
         => new((float)((unit.X - 0.5) * 2.0 * activeRadius + canvasRadius),
                (float)((unit.Y - 0.5) * 2.0 * activeRadius + canvasRadius));
 
@@ -462,7 +397,7 @@ public class ColorTriangleArea : SkiaPickerBase
     float SvRadius(float canvasRadius) => canvasRadius - (2 * GetIndicatorRadiusPixels()) - 2;
     float HRadius(float canvasRadius) => canvasRadius - GetIndicatorRadiusPixels();
 
-    void PaintLinePicker(SKCanvas canvas)
+    void PaintLinePicker(SKCanvas canvas, SKPoint outer, SKPoint inner)
     {
         var paint = new SKPaint
         {
@@ -474,8 +409,8 @@ public class ColorTriangleArea : SkiaPickerBase
         paint.StrokeWidth = 4;
 
         using var pathTriangle = new SKPath();
-        pathTriangle.MoveTo(_locationH1);
-        pathTriangle.LineTo(_locationH2);
+        pathTriangle.MoveTo(outer);
+        pathTriangle.LineTo(inner);
 
         canvas.DrawPath(pathTriangle, paint);
     }

--- a/ColorPicker/Controls/ColorTriangleArea.cs
+++ b/ColorPicker/Controls/ColorTriangleArea.cs
@@ -156,6 +156,11 @@ public class ColorTriangleArea : SkiaPickerBase
         var canvasRadius = GetSize() / 2F;
         var (offX, offY) = GetDrawingOffset();
 
+        // Re-sync from SelectedColor each paint so the controller picks up
+        // any external bindable-property change (incl. the initial default
+        // that never fires OnSelectedColorChanging).
+        Interaction.SyncFromColor(SelectedColor.ToHsla());
+
         // Compute paint-time pixel positions of indicators from the
         // controller's unit-space locations.
         var locationSv = UnitToPixel(Interaction.LocationSv, canvasRadius, SvRadius(canvasRadius));


### PR DESCRIPTION
## Why

PR #36 fixed a hue-drift bug on the rotating triangle by splitting the per-touch `UpdateColors` into `UpdateColorsFromSv` / `UpdateColorsFromH`. The fix lived in MAUI shell code, so the only regression coverage was an Appium drag test. This PR lifts that contract into platform-agnostic controllers in `ColorPicker.Core` so the same invariant is enforced by fast, deterministic unit tests — and preemptively applies the analogous split to `ColorDisc` (which had the same bug pattern, untriggered).

## What

* New `ColorPicker.Core/Interaction/TriangleAreaInteraction.cs` — holds `LastHue`, `ZeroSL`, `LocationSv`, `LocationH`, `Color` in unit-space; `UpdateFromSv` / `UpdateFromH` decode only their region. H drag re-encodes SV for the rotating triangle.
* New `ColorPicker.Core/Interaction/ColorDiscInteraction.cs` — same per-region split for HS / L.
* `ColorTriangleArea.cs` and `ColorDisc.cs` are now thin pixel ↔ unit-space adapters that delegate to the controllers.

## Tests

* 10 new deterministic Core tests (1356 total green) including:
  * `HueDrag_DoesNotDrift_S_or_L` on rotating and fixed triangles (tolerance 1e-9).
  * `NaiveCrossDecode_Drifts_OnRotatedTriangle` — proves the guards are not vacuous (~0.01 drift in the naive path).
  * `LDrag_DoesNotChange_H_or_S` and `HsDrag_DoesNotChange_L` for ColorDisc.
* Full UI suite: 201/214 passing — the 13 failures (PaddingTests / BackgroundTests / 3 ColorSyncTests) all reproduce on `main` and are unrelated to this change.

## Notes

* `TriangleHueDriftTests` still passes — the Appium-level guard remains as a defense-in-depth.
* No public API change; only the internal touch/paint plumbing is touched in the MAUI shells.